### PR TITLE
fix!: avoid `eslint-plugin-jsx-a11y@6.8.0`

### DIFF
--- a/change/@rightcapital-eslint-config-typescript-react-c0cd8250-e391-4a1d-94a9-684d8b7176fc.json
+++ b/change/@rightcapital-eslint-config-typescript-react-c0cd8250-e391-4a1d-94a9-684d8b7176fc.json
@@ -1,0 +1,7 @@
+{
+  "comment": "fix!: avoid `eslint-plugin-jsx-a11y@6.8.0`",
+  "type": "major",
+  "packageName": "@rightcapital/eslint-config-typescript-react",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-typescript-react/package.json
+++ b/packages/eslint-config-typescript-react/package.json
@@ -28,7 +28,7 @@
     "eslint-config-prettier": "9.0.0",
     "@rushstack/eslint-patch": "1.5.1",
     "eslint-config-airbnb": "19.0.4",
-    "eslint-plugin-jsx-a11y": "6.8.0",
+    "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-react": "7.33.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,13 +127,13 @@ importers:
         version: 8.53.0
       eslint-config-airbnb:
         specifier: 19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.0)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.53.0)
+        version: 19.0.4(eslint-plugin-import@2.29.0)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.53.0)
       eslint-config-prettier:
         specifier: 9.0.0
         version: 9.0.0(eslint@8.53.0)
       eslint-plugin-jsx-a11y:
-        specifier: 6.8.0
-        version: 6.8.0(eslint@8.53.0)
+        specifier: 6.7.1
+        version: 6.7.1(eslint@8.53.0)
       eslint-plugin-react:
         specifier: 7.33.2
         version: 7.33.2(eslint@8.53.0)
@@ -2634,8 +2634,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /ast-types-flow@0.0.8:
-    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+  /ast-types-flow@0.0.7:
+    resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
     dev: false
 
   /asynciterator.prototype@1.0.0:
@@ -3508,7 +3508,7 @@ packages:
       semver: 6.3.1
     dev: false
 
-  /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.0)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.53.0):
+  /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.0)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.53.0):
     resolution: {integrity: sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==}
     engines: {node: ^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3521,7 +3521,7 @@ packages:
       eslint: 8.53.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.0)(eslint@8.53.0)
       eslint-plugin-import: 2.29.0(eslint@8.53.0)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.53.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.53.0)
       eslint-plugin-react: 7.33.2(eslint@8.53.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
       object.assign: 4.1.4
@@ -3656,8 +3656,8 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-jsx-a11y@6.8.0(eslint@8.53.0):
-    resolution: {integrity: sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==}
+  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.53.0):
+    resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -3666,19 +3666,19 @@ packages:
       aria-query: 5.3.0
       array-includes: 3.1.7
       array.prototype.flatmap: 1.3.2
-      ast-types-flow: 0.0.8
+      ast-types-flow: 0.0.7
       axe-core: 4.7.0
       axobject-query: 3.2.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.15
       eslint: 8.53.0
-      hasown: 2.0.0
+      has: 1.0.4
       jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
+      language-tags: 1.0.5
       minimatch: 3.1.2
       object.entries: 1.1.7
       object.fromentries: 2.0.7
+      semver: 6.3.1
     dev: false
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.53.0):
@@ -4264,6 +4264,11 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: false
+
+  /has@1.0.4:
+    resolution: {integrity: sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==}
+    engines: {node: '>= 0.4.0'}
     dev: false
 
   /hasown@2.0.0:
@@ -5224,9 +5229,8 @@ packages:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: false
 
-  /language-tags@1.0.9:
-    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
-    engines: {node: '>=0.10'}
+  /language-tags@1.0.5:
+    resolution: {integrity: sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==}
     dependencies:
       language-subtag-registry: 0.3.22
     dev: false

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchPackagePrefixes": ["@rightcapital"],
       "automerge": false
+    },
+    {
+      "description": "Skip problematic eslint-plugin-jsx-a11y@6.8.0 version",
+      "matchPackageNames": ["eslint-plugin-jsx-a11y"],
+      "allowedVersions": ">6.8.0"
     }
   ]
 }


### PR DESCRIPTION
`eslint-plugin-jsx-a11y@6.8.0` throws too many false positives.

- Disallow eslint-plugin-jsx-a11y@6.8.0 in renovate config
- Downgrade eslint-plugin-jsx-a11y from 6.8.0 to 6.7.1

resolves #45