### PR TITLE
feat: update React hook names for checking

### DIFF
--- a/change/@rightcapital-eslint-plugin-e2bccf47-b2d8-4b79-9d23-41552b868997.json
+++ b/change/@rightcapital-eslint-plugin-e2bccf47-b2d8-4b79-9d23-41552b868997.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: update React hook names for checking",
+  "packageName": "@rightcapital/eslint-plugin",
+  "email": "45930107+PinkChampagne17@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks.ts
+++ b/packages/eslint-plugin/src/rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks.ts
@@ -6,6 +6,7 @@ import { getDocumentUrl } from '../../helpers/get-document-url';
 // https://react.dev/reference/react/hooks
 // https://react.dev/reference/react-dom/hooks
 const hooksToCheck = [
+  'useActionState',
   'useCallback',
   'useContext',
   'useDeferredValue',
@@ -17,7 +18,6 @@ const hooksToCheck = [
   'useState',
   'useSyncExternalStore',
   'useTransition',
-  'useFormState',
   'useFormStatus',
 ];
 


### PR DESCRIPTION
`React.useActionState` was previously called `ReactDOM.useFormState` in the Canary releases, but React team renamed it and deprecated `useFormState`.

See post [React 19 Beta](https://react.dev/blog/2024/04/25/react-19#new-feature-optimistic-updates:~:text=React.useActionState%20was%20previously%20called%20ReactDOM.useFormState%20in%20the%20Canary%20releases%2C%20but%20we%E2%80%99ve%20renamed%20it%20and%20deprecated%20useFormState.).