### PR TITLE
feat!: avoid using explicit type for function component

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,10 +28,6 @@ module.exports = {
         'packages/**/*.{ts,cts,mts}',
       ],
       extends: '@rightcapital/typescript',
-      parserOptions: {
-        tsconfigRootDir: __dirname,
-        EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
-      },
       rules: {
         'no-unused-expressions': ['error', { allowTaggedTemplates: true }],
         'import/no-extraneous-dependencies': 'off',

--- a/change/@rightcapital-eslint-config-base-ca6cfe8e-7cff-45ee-a02b-95cf34857b61.json
+++ b/change/@rightcapital-eslint-config-base-ca6cfe8e-7cff-45ee-a02b-95cf34857b61.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat!: avoid explicit function component type",
+  "packageName": "@rightcapital/eslint-config-base",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "none"
+}

--- a/change/@rightcapital-eslint-config-javascript-a63ce810-c67b-4002-9462-cb13aeec5745.json
+++ b/change/@rightcapital-eslint-config-javascript-a63ce810-c67b-4002-9462-cb13aeec5745.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat!: avoid explicit function component type",
+  "packageName": "@rightcapital/eslint-config-javascript",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "none"
+}

--- a/change/@rightcapital-eslint-config-typescript-ed5a4571-919b-40a8-b2b6-c45bbb146cf5.json
+++ b/change/@rightcapital-eslint-config-typescript-ed5a4571-919b-40a8-b2b6-c45bbb146cf5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat!: avoid explicit function component type",
+  "packageName": "@rightcapital/eslint-config-typescript",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "none"
+}

--- a/change/@rightcapital-eslint-config-typescript-react-8606677d-e829-40f7-97b5-3a52bf36fe95.json
+++ b/change/@rightcapital-eslint-config-typescript-react-8606677d-e829-40f7-97b5-3a52bf36fe95.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat!: avoid explicit function component type",
+  "packageName": "@rightcapital/eslint-config-typescript-react",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/change/@rightcapital-eslint-plugin-0ee20123-6d41-47bf-9f91-546ab366ff03.json
+++ b/change/@rightcapital-eslint-plugin-0ee20123-6d41-47bf-9f91-546ab366ff03.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat!: avoid explicit function component type",
+  "packageName": "@rightcapital/eslint-plugin",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:eslint": "eslint --max-warnings=0 .",
     "lint:prettier": "prettier -c .",
     "prepare": "./scripts/prepare.sh",
-    "test": "pnpm --aggregate-output --filter './specs/*' test",
+    "test": "pnpm run --recursive --aggregate-output --reporter-hide-prefix test",
     "test:update-snapshots": "pnpm --aggregate-output --filter './specs/*' test -- -u"
   },
   "config": {

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -17,7 +17,9 @@
     "lib/index.d.ts"
   ],
   "scripts": {
-    "build": "tsc --build --clean && tsc --build",
+    "prebuild": "pnpm run clean",
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/eslint-config-javascript/package.json
+++ b/packages/eslint-config-javascript/package.json
@@ -17,7 +17,9 @@
     "lib/index.d.ts"
   ],
   "scripts": {
-    "build": "tsc --build --clean && tsc --build",
+    "prebuild": "pnpm run clean",
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/eslint-config-typescript-react/package.json
+++ b/packages/eslint-config-typescript-react/package.json
@@ -17,7 +17,9 @@
     "lib/index.d.ts"
   ],
   "scripts": {
-    "build": "tsc --build --clean && tsc --build",
+    "prebuild": "pnpm run clean",
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/eslint-config-typescript-react/src/index.ts
+++ b/packages/eslint-config-typescript-react/src/index.ts
@@ -16,6 +16,7 @@ const config: Linter.Config = {
     'jsx-a11y/anchor-is-valid': 'off',
     'jsx-a11y/click-events-have-key-events': 'off',
     '@eslint-react/no-useless-fragment': ['error'],
+    '@rightcapital/no-explicit-type-on-function-component-identifier': 'error',
   },
 };
 

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -17,7 +17,9 @@
     "lib/index.d.ts"
   ],
   "scripts": {
-    "build": "tsc --build --clean && tsc --build",
+    "prebuild": "pnpm run clean",
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/eslint-config-typescript/src/index.ts
+++ b/packages/eslint-config-typescript/src/index.ts
@@ -8,8 +8,11 @@ const config: Linter.Config = {
     'plugin:@typescript-eslint/recommended-type-checked',
   ],
   parser: require.resolve('@typescript-eslint/parser'),
+  plugins: ['@rightcapital'],
   // https://typescript-eslint.io/packages/parser/#configuration
-  parserOptions: { project: true },
+  parserOptions: {
+    EXPERIMENTAL_useProjectService: true,
+  },
   settings: {
     'import/parsers': {
       '@typescript-eslint/parser': ['.ts', '.cts', '.mts', '.tsx'],
@@ -114,6 +117,7 @@ const config: Linter.Config = {
     ],
     '@typescript-eslint/no-import-type-side-effects': 'error',
     'import/no-duplicates': ['error', { 'prefer-inline': true }],
+    '@rightcapital/no-explicit-type-on-function-component-identifier': 'error',
   },
 };
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -2,11 +2,13 @@
 
 <!-- begin auto-generated rules list -->
 
-💼 Configurations enabled in.
+💼 Configurations enabled in.\
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                                                                              | Description                                    | 💼                           |
-| :-------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------- | :--------------------------- |
-| [jsx-no-unused-expressions](src/rules/jsx-no-unused-expressions/jsx-no-unused-expressions.md)                                     | Disallow unused JSX expressions                | ![badge-recommended-jsx][]   |
-| [no-ignore-return-value-of-react-hooks](src/rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks.md) | Disallow ignoring return value of React hooks. | ![badge-recommended-react][] |
+| Name                                                                                                                                                                  | Description                                                                                                     | 💼                           | 🔧  |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- | :--------------------------- | :-- |
+| [jsx-no-unused-expressions](src/rules/jsx-no-unused-expressions/jsx-no-unused-expressions.md)                                                                         | Disallow unused JSX expressions                                                                                 | ![badge-recommended-jsx][]   |     |
+| [no-explicit-type-on-function-component-identifier](src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.md) | Disallow explicitly specifying type for function component identifier. (This rule requires `typescript-eslint`) |                              | 🔧  |
+| [no-ignore-return-value-of-react-hooks](src/rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks.md)                                     | Disallow ignoring return value of React hooks.                                                                  | ![badge-recommended-react][] |     |
 
 <!-- end auto-generated rules list -->

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -16,16 +16,23 @@
   "exports": "./lib/index.js",
   "main": "./lib/index.js",
   "scripts": {
-    "build": "tsc --build --clean && tsc --build",
+    "prebuild": "pnpm run clean",
+    "build": "tsc --build tsconfig.lib.json",
+    "clean": "tsc --build tsconfig.lib.json --clean",
     "prepack": "pnpm run build",
-    "test": "vitest",
+    "test": "vitest --coverage",
     "test:ui": "vitest --ui",
     "update:eslint-docs": "pnpm run build && eslint-doc-generator && prettier --write src/rules/**/*.md"
+  },
+  "dependencies": {
+    "@typescript-eslint/utils": "7.13.1"
   },
   "devDependencies": {
     "@rightcapital/tsconfig": "workspace:*",
     "@types/eslint": "8.56.10",
     "@types/node": "20.14.4",
+    "@typescript-eslint/rule-tester": "7.13.1",
+    "@vitest/coverage-v8": "1.6.0",
     "@vitest/ui": "1.6.0",
     "eslint": "8.57.0",
     "eslint-doc-generator": "1.7.1",

--- a/packages/eslint-plugin/src/configs/recommended-jsx.ts
+++ b/packages/eslint-plugin/src/configs/recommended-jsx.ts
@@ -1,6 +1,6 @@
-import type { ESLint } from 'eslint';
+import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
-export const recommendedJsxConfig: ESLint.ConfigData = {
+export const recommendedJsxConfig: ClassicConfig.Config = {
   overrides: [
     {
       files: '**/*.{jsx,tsx}',

--- a/packages/eslint-plugin/src/configs/recommended-react.ts
+++ b/packages/eslint-plugin/src/configs/recommended-react.ts
@@ -1,6 +1,6 @@
-import type { ESLint } from 'eslint';
+import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
-export const recommendedReactConfig: ESLint.ConfigData = {
+export const recommendedReactConfig: ClassicConfig.Config = {
   extends: ['plugin:@rightcapital/recommended-jsx'],
   rules: {
     '@rightcapital/no-ignore-return-value-of-react-hooks': 'error',

--- a/packages/eslint-plugin/src/helpers/ast/function/is-call-of.ts
+++ b/packages/eslint-plugin/src/helpers/ast/function/is-call-of.ts
@@ -1,6 +1,6 @@
-import type { Rule } from 'eslint';
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
+import { isNodeOfType } from '@typescript-eslint/utils/ast-utils';
 
-type IESLintCallExpressionNode = Extract<Rule.Node, { type: 'CallExpression' }>;
 type Predicate = string | string[] | ((id: string) => boolean);
 
 const matchCalleeName = (predicate: Predicate, name: string) => {
@@ -14,12 +14,12 @@ const matchCalleeName = (predicate: Predicate, name: string) => {
 };
 
 export function isCallOf(
-  node: Rule.Node,
+  node: TSESTree.Node,
   predicate: Predicate,
-): node is IESLintCallExpressionNode {
+): node is TSESTree.CallExpression {
   return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'Identifier' &&
+    isNodeOfType(AST_NODE_TYPES.CallExpression)(node) &&
+    isNodeOfType(AST_NODE_TYPES.Identifier)(node.callee) &&
     matchCalleeName(predicate, node.callee.name)
   );
 }

--- a/packages/eslint-plugin/src/helpers/create-rule.ts
+++ b/packages/eslint-plugin/src/helpers/create-rule.ts
@@ -1,0 +1,5 @@
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+
+import { getDocumentUrl } from './get-document-url';
+
+export const createRule = RuleCreator(getDocumentUrl);

--- a/packages/eslint-plugin/src/helpers/test/vitest-rule-tester.ts
+++ b/packages/eslint-plugin/src/helpers/test/vitest-rule-tester.ts
@@ -1,8 +1,16 @@
-import { RuleTester } from 'eslint';
-import { describe, test } from 'vitest';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { afterAll, describe, test } from 'vitest';
 
 export class VitestRuleTester extends RuleTester {
   static describe: typeof describe = describe;
 
+  static describeSkip: typeof describe.skip = describe.skip;
+
   static it: typeof test = test;
+
+  static itOnly: typeof test.only = test.only;
+
+  static itSkip: typeof test.skip = test.skip;
+
+  static afterAll: typeof afterAll = afterAll;
 }

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,23 +1,26 @@
-import type { ESLint } from 'eslint';
+import type { Linter } from '@typescript-eslint/utils/ts-eslint';
 
 import { name, version } from '../package.json';
 import { recommendedJsxConfig } from './configs/recommended-jsx';
 import { recommendedReactConfig } from './configs/recommended-react';
 import { jsxNoUnusedExpressionsRule } from './rules/jsx-no-unused-expressions/jsx-no-unused-expressions';
+import { noExplicitTypeOnFunctionComponentIdentifierRule } from './rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier';
 import { noIgnoreReturnValueOfReactHooksRule } from './rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks';
 
 // eslint-doc-generator can't resolve default export
-export const meta: ESLint.Plugin['meta'] = {
+export const meta: Linter.Plugin['meta'] = {
   name,
   version,
 };
 
-export const configs: ESLint.Plugin['configs'] = {
+export const configs: Linter.Plugin['configs'] = {
   'recommended-jsx': recommendedJsxConfig,
   'recommended-react': recommendedReactConfig,
 };
 
-export const rules: ESLint.Plugin['rules'] = {
+export const rules: Linter.Plugin['rules'] = {
   'jsx-no-unused-expressions': jsxNoUnusedExpressionsRule,
   'no-ignore-return-value-of-react-hooks': noIgnoreReturnValueOfReactHooksRule,
+  'no-explicit-type-on-function-component-identifier':
+    noExplicitTypeOnFunctionComponentIdentifierRule,
 };

--- a/packages/eslint-plugin/src/rules/jsx-no-unused-expressions/jsx-no-unused-expressions.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-no-unused-expressions/jsx-no-unused-expressions.test.ts
@@ -4,8 +4,8 @@ import { VitestRuleTester } from '../../helpers/test/vitest-rule-tester';
 import { jsxNoUnusedExpressionsRule } from './jsx-no-unused-expressions';
 
 const ruleTester = new VitestRuleTester({
+  parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 'latest',
     ecmaFeatures: {
       jsx: true,
     },
@@ -31,7 +31,7 @@ ruleTester.run(basename(__dirname), jsxNoUnusedExpressionsRule, {
     {
       name: 'Not assigned to a variable',
       code: '<div />',
-      errors: 1,
+      errors: [{ messageId: 'unusedExpression' }],
     },
   ],
 });

--- a/packages/eslint-plugin/src/rules/jsx-no-unused-expressions/jsx-no-unused-expressions.ts
+++ b/packages/eslint-plugin/src/rules/jsx-no-unused-expressions/jsx-no-unused-expressions.ts
@@ -1,26 +1,27 @@
 import { basename } from 'node:path';
 
-import type { Rule } from 'eslint';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { isNodeOfType } from '@typescript-eslint/utils/ast-utils';
 
-import { getDocumentUrl } from '../../helpers/get-document-url';
+import { createRule } from '../../helpers/create-rule';
 
-export const jsxNoUnusedExpressionsRule: Rule.RuleModule = {
+export const jsxNoUnusedExpressionsRule = createRule({
+  name: basename(__dirname),
   meta: {
     type: 'problem',
+    schema: [],
     docs: {
       description: 'Disallow unused JSX expressions',
-      url: getDocumentUrl(basename(__dirname)),
     },
-    schema: [],
     messages: {
       unusedExpression: 'Expected an assignment instead saw an JSX expression',
     },
   },
+  defaultOptions: [],
   create(context) {
     return {
       ExpressionStatement(node) {
-        // @ts-expect-error The type is missing `JSXElement` type.
-        if (node.expression.type === 'JSXElement') {
+        if (isNodeOfType(AST_NODE_TYPES.JSXElement)(node.expression)) {
           context.report({
             node,
             messageId: 'unusedExpression',
@@ -29,4 +30,4 @@ export const jsxNoUnusedExpressionsRule: Rule.RuleModule = {
       },
     };
   },
-};
+});

--- a/packages/eslint-plugin/src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.md
+++ b/packages/eslint-plugin/src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.md
@@ -1,0 +1,5 @@
+# Disallow explicitly specifying type for function component identifier. (This rule requires `typescript-eslint`) (`@rightcapital/no-explicit-type-on-function-component-identifier`)
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.test.ts
+++ b/packages/eslint-plugin/src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.test.ts
@@ -1,0 +1,130 @@
+import { basename } from 'node:path';
+
+import type { InvalidTestCase } from '@typescript-eslint/rule-tester';
+
+import { VitestRuleTester } from '../../helpers/test/vitest-rule-tester.js';
+import {
+  disallowedTypeNames,
+  noExplicitTypeOnFunctionComponentIdentifierRule,
+} from './no-explicit-type-on-function-component-identifier.js';
+
+const ruleTester = new VitestRuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const functionComponentTypes = [
+  'FC',
+  'React.FC',
+  'FunctionComponent',
+  'React.FunctionComponent',
+];
+
+ruleTester.run(
+  basename(__dirname),
+  noExplicitTypeOnFunctionComponentIdentifierRule,
+  {
+    valid: [
+      {
+        name: 'No explicit type',
+        code: 'const MyComponent = () => <div />',
+      },
+      {
+        name: 'Custom named type',
+        code: 'const MyComponent: NotAComponentType = () => <div />',
+      },
+      {
+        name: 'Custom type expression',
+        code: 'const MyComponent: () => React.ReactElement = () => <div />',
+      },
+    ],
+    invalid: Array.from(
+      (function* invalidTestCaseGenerator(): Generator<
+        InvalidTestCase<'avoidExplicitFunctionComponentType', []>
+      > {
+        for (const typeName of disallowedTypeNames) {
+          yield {
+            name: `${typeName} - arrow function`,
+            code: `const MyComponent: ${typeName} = () => <div />`,
+            output: 'const MyComponent = () => <div />',
+            errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+          };
+
+          if (functionComponentTypes.includes(typeName)) {
+            yield {
+              name: `${typeName} - arrow function + generic`,
+              code: `const MyComponent: ${typeName}<IProps> = (props) => <div />`,
+              output: 'const MyComponent = (props: IProps) => <div />',
+              errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+            };
+
+            yield {
+              name: `${typeName} - arrow function + generic + redundant type annotation`,
+              code: `const MyComponent: ${typeName}<IProps> = (props: JProps) => <div />`,
+              output: 'const MyComponent = (props: JProps) => <div />',
+              errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+            };
+
+            yield {
+              name: `${typeName} - arrow function + generic + destructured props`,
+              code: `const MyComponent: ${typeName}<IProps> = ({ name }) => <div />`,
+              output: 'const MyComponent = ({ name }: IProps) => <div />',
+              errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+            };
+
+            yield {
+              name: `${typeName} - arrow function + generic + destructured props + redundant type annotation`,
+              code: `const MyComponent: ${typeName}<IProps> = ({ name }: JProps) => <div />`,
+              output: 'const MyComponent = ({ name }: JProps) => <div />',
+              errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+            };
+          }
+
+          yield {
+            name: `${typeName} - function`,
+            code: `const MyComponent: ${typeName} = function () { return <div /> }`,
+            output: 'const MyComponent = function () { return <div /> }',
+            errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+          };
+          if (functionComponentTypes.includes(typeName)) {
+            yield {
+              name: `${typeName} - function + generic`,
+              code: `const MyComponent: ${typeName}<IProps> = function (props) { return <div /> }`,
+              output:
+                'const MyComponent = function (props: IProps) { return <div /> }',
+              errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+            };
+
+            yield {
+              name: `${typeName} - function + generic + redundant type annotation`,
+              code: `const MyComponent: ${typeName}<IProps> = function (props: JProps) { return <div /> }`,
+              output:
+                'const MyComponent = function (props: JProps) { return <div /> }',
+              errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+            };
+
+            yield {
+              name: `${typeName} - function + generic + destructured props`,
+              code: `const MyComponent: ${typeName}<IProps> = function ({ name }) { return <div /> }`,
+              output:
+                'const MyComponent = function ({ name }: IProps) { return <div /> }',
+              errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+            };
+
+            yield {
+              name: `${typeName} - function + generic + destructured props + redundant type annotation`,
+              code: `const MyComponent: ${typeName}<IProps> = function ({ name }: JProps) { return <div /> }`,
+              output:
+                'const MyComponent = function ({ name }: JProps) { return <div /> }',
+              errors: [{ messageId: 'avoidExplicitFunctionComponentType' }],
+            };
+          }
+        }
+      })(),
+    ),
+  },
+);

--- a/packages/eslint-plugin/src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.ts
+++ b/packages/eslint-plugin/src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.ts
@@ -1,0 +1,176 @@
+import { basename } from 'node:path';
+
+import {
+  AST_NODE_TYPES,
+  type TSESLint,
+  type TSESTree,
+} from '@typescript-eslint/utils';
+import {
+  isNodeOfType,
+  isNodeOfTypes,
+} from '@typescript-eslint/utils/ast-utils';
+
+import { createRule } from '../../helpers/create-rule';
+
+const isFunctionComponentName = (name: string) => /^[A-Z]/.test(name);
+
+const isFunctionComponentVariableDeclearator = (
+  declarator: TSESTree.VariableDeclarator,
+): boolean =>
+  isNodeOfType(AST_NODE_TYPES.Identifier)(declarator.id) &&
+  isFunctionComponentName(declarator.id.name) &&
+  isNodeOfTypes([
+    AST_NODE_TYPES.ArrowFunctionExpression,
+    AST_NODE_TYPES.FunctionExpression,
+  ])(declarator.init);
+
+const getTypeNameFromVariableDeclarator = (
+  declarator: TSESTree.VariableDeclarator,
+  context: Readonly<
+    TSESLint.RuleContext<'avoidExplicitFunctionComponentType', []>
+  >,
+): string | undefined => {
+  if (
+    isNodeOfType(AST_NODE_TYPES.TSTypeAnnotation)(
+      declarator.id.typeAnnotation,
+    ) &&
+    isNodeOfType(AST_NODE_TYPES.TSTypeReference)(
+      declarator.id.typeAnnotation.typeAnnotation,
+    )
+  ) {
+    // let a: TypeName ----> TypeName
+    if (
+      isNodeOfType(AST_NODE_TYPES.Identifier)(
+        declarator.id.typeAnnotation.typeAnnotation.typeName,
+      )
+    ) {
+      return declarator.id.typeAnnotation.typeAnnotation.typeName.name;
+    }
+
+    // let a: TypeName<T> ----> TypeName
+    if (
+      isNodeOfType(AST_NODE_TYPES.TSQualifiedName)(
+        declarator.id.typeAnnotation.typeAnnotation.typeName,
+      )
+    ) {
+      return context.sourceCode.getText(
+        declarator.id.typeAnnotation.typeAnnotation.typeName,
+      );
+    }
+  }
+
+  return undefined;
+};
+
+const getTypeArgumentsTextFromVariableDeclearator = (
+  declarator: TSESTree.VariableDeclarator,
+  context: Readonly<
+    TSESLint.RuleContext<'avoidExplicitFunctionComponentType', []>
+  >,
+): string[] | undefined => {
+  if (
+    isNodeOfType(AST_NODE_TYPES.TSTypeAnnotation)(
+      declarator.id.typeAnnotation,
+    ) &&
+    isNodeOfType(AST_NODE_TYPES.TSTypeReference)(
+      declarator.id.typeAnnotation.typeAnnotation,
+    ) &&
+    declarator.id.typeAnnotation.typeAnnotation.typeArguments &&
+    declarator.id.typeAnnotation.typeAnnotation.typeArguments.params.length > 0
+  ) {
+    const typeArgumentsNode =
+      declarator.id.typeAnnotation.typeAnnotation.typeArguments;
+    // let a: TypeName<T1, T2> ----> ["T1", "T2"]
+    return typeArgumentsNode.params.map((param) =>
+      context.sourceCode.getText(param),
+    );
+  }
+
+  return undefined;
+};
+
+export const disallowedTypeNames = [
+  'FC',
+  'React.FC',
+  'FunctionComponent',
+  'React.FunctionComponent',
+  'ComponentClass',
+  'React.ComponentClass',
+  'ComponentType',
+  'React.ComponentType',
+];
+
+export const noExplicitTypeOnFunctionComponentIdentifierRule = createRule({
+  name: basename(__dirname),
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    docs: {
+      description:
+        'Disallow explicitly specifying type for function component identifier. (This rule requires `typescript-eslint`)',
+    },
+    schema: [],
+    messages: {
+      avoidExplicitFunctionComponentType:
+        'Avoid explicitly specifying type for function component identifier. Specify the type of the props instead.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      VariableDeclaration(node) {
+        for (const declarator of node.declarations) {
+          if (isFunctionComponentVariableDeclearator(declarator)) {
+            const typeName = getTypeNameFromVariableDeclarator(
+              declarator,
+              context,
+            );
+            const typeArguments = getTypeArgumentsTextFromVariableDeclearator(
+              declarator,
+              context,
+            );
+            if (typeName && disallowedTypeNames.includes(typeName)) {
+              context.report({
+                node: declarator.id,
+                messageId: 'avoidExplicitFunctionComponentType',
+                fix(fixer) {
+                  if (
+                    typeArguments?.length === 1 &&
+                    // the right side is an (arrow) function expression
+                    isNodeOfTypes([
+                      AST_NODE_TYPES.ArrowFunctionExpression,
+                      AST_NODE_TYPES.FunctionExpression,
+                    ])(declarator.init) &&
+                    // only one parameter
+                    declarator.init.params.length === 1 &&
+                    isNodeOfTypes([
+                      AST_NODE_TYPES.Identifier,
+                      AST_NODE_TYPES.ObjectPattern,
+                    ])(declarator.init.params[0]) &&
+                    // the parameter doesn't have type annotation
+                    !declarator.init.params[0].typeAnnotation
+                  ) {
+                    const propType = typeArguments[0];
+                    return [
+                      // `typeName` is a string means that the type annotation exists.
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                      fixer.remove(declarator.id.typeAnnotation!),
+                      fixer.insertTextAfter(
+                        declarator.init.params[0],
+                        `: ${propType}`,
+                      ),
+                    ];
+                  }
+
+                  // `typeName` is a string means that the type annotation exists.
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  return fixer.remove(declarator.id.typeAnnotation!);
+                },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks.test.ts
+++ b/packages/eslint-plugin/src/rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks.test.ts
@@ -3,11 +3,7 @@ import { basename } from 'node:path';
 import { VitestRuleTester } from '../../helpers/test/vitest-rule-tester';
 import { noIgnoreReturnValueOfReactHooksRule } from './no-ignore-return-value-of-react-hooks';
 
-const ruleTester = new VitestRuleTester({
-  parserOptions: {
-    ecmaVersion: 'latest',
-  },
-});
+const ruleTester = new VitestRuleTester();
 
 ruleTester.run(basename(__dirname), noIgnoreReturnValueOfReactHooksRule, {
   valid: [
@@ -44,22 +40,22 @@ ruleTester.run(basename(__dirname), noIgnoreReturnValueOfReactHooksRule, {
     {
       name: 'Not assigned to a variable',
       code: 'useState(0)',
-      errors: 1,
+      errors: [{ messageId: 'ignoreReturnValue' }],
     },
     {
       name: 'Not assigned to a variable in component',
       code: 'function Foo() { useState(0); }',
-      errors: 1,
+      errors: [{ messageId: 'ignoreReturnValue' }],
     },
     {
       name: 'Access the property of the return value',
       code: 'useState(0)[0];',
-      errors: 1,
+      errors: [{ messageId: 'ignoreReturnValue' }],
     },
     {
       name: 'Access the property of the return value with optional chaining',
       code: 'useState(0)[0]?.foo;',
-      errors: 1,
+      errors: [{ messageId: 'ignoreReturnValue' }],
     },
   ],
 });

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "@rightcapital/tsconfig",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "rootDir": "./src",
-    "verbatimModuleSyntax": false
-  },
-  "include": ["./src"]
+  "compilerOptions": { "composite": true },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.scripts.json" }
+  ]
 }

--- a/packages/eslint-plugin/tsconfig.lib.json
+++ b/packages/eslint-plugin/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rightcapital/tsconfig",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "verbatimModuleSyntax": false
+  },
+  "include": ["./src"]
+}

--- a/packages/eslint-plugin/tsconfig.scripts.json
+++ b/packages/eslint-plugin/tsconfig.scripts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@rightcapital/tsconfig",
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  },
+  "include": ["*.ts", "*.mts", "*.cts"],
+  "exclude": ["src"]
+}

--- a/packages/eslint-plugin/vitest.config.mts
+++ b/packages/eslint-plugin/vitest.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.{ts,cts,mts,tsx}'],
+    coverage: {
+      provider: 'v8',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,10 @@ importers:
         version: link:../tsconfig
 
   packages/eslint-plugin:
+    dependencies:
+      '@typescript-eslint/utils':
+        specifier: 7.13.1
+        version: 7.13.1(eslint@8.57.0)(typescript@5.4.5)
     devDependencies:
       '@rightcapital/tsconfig':
         specifier: workspace:*
@@ -186,6 +190,12 @@ importers:
       '@types/node':
         specifier: 20.14.4
         version: 20.14.4
+      '@typescript-eslint/rule-tester':
+        specifier: 7.13.1
+        version: 7.13.1(@eslint/eslintrc@3.1.0)(eslint@8.57.0)(typescript@5.4.5)
+      '@vitest/coverage-v8':
+        specifier: 1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.14.4)(@vitest/ui@1.6.0))
       '@vitest/ui':
         specifier: 1.6.0
         version: 1.6.0(vitest@1.6.0)
@@ -287,6 +297,9 @@ importers:
       prettier:
         specifier: 3.3.2
         version: 3.3.2
+      typescript-eslint:
+        specifier: 7.13.1
+        version: 7.13.1(eslint@8.57.0)(typescript@5.4.5)
 
 packages:
 
@@ -1620,6 +1633,13 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/rule-tester@7.13.1':
+    resolution: {integrity: sha512-rM55VW1cWHLKys8cKKa2RjRUasB5k3hniuwixZXX28oayk9QCiAhbKTJjkbYAkXjOOyfEN+ReVFTvvTNWGOvDA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@eslint/eslintrc': '>=2'
+      eslint: ^8.56.0
+
   '@typescript-eslint/scope-manager@5.62.0':
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1686,6 +1706,11 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  '@vitest/coverage-v8@1.6.0':
+    resolution: {integrity: sha512-KvapcbMY/8GYIG0rlwwOKCVNRc0OL20rrhFkg/CHNzncV03TE2XWvO5w9uZYoxNiMEBacAJt3unSOiZ7svePew==}
+    peerDependencies:
+      vitest: 1.6.0
 
   '@vitest/expect@1.6.0':
     resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
@@ -3087,6 +3112,10 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
+  istanbul-lib-source-maps@5.0.4:
+    resolution: {integrity: sha512-wHOoEsNJTVltaJp8eVkm8w+GVkVNHT2YDYo53YdzQEL2gWm1hBX5cGFR9hQJtuGLebidVX7et3+dmDZrmclduw==}
+    engines: {node: '>=10'}
+
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
@@ -3396,6 +3425,9 @@ packages:
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
+
+  magicast@0.3.4:
+    resolution: {integrity: sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -3944,6 +3976,10 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
+  source-map-js@1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
@@ -4202,6 +4238,16 @@ packages:
   typed-array-length@1.0.6:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@7.13.1:
+    resolution: {integrity: sha512-pvLEuRs8iS9s3Cnp/Wt//hpK8nKc8hVa3cLljHqzaJJQYP8oys8GUyIFqtlev+2lT/fqMPcyQko+HJ6iYK3nFA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
@@ -6039,6 +6085,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/rule-tester@7.13.1(@eslint/eslintrc@3.1.0)(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint/eslintrc': 3.1.0
+      '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.4.5)
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      ajv: 6.12.6
+      eslint: 8.57.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      semver: 7.6.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/scope-manager@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -6131,6 +6191,25 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
+
+  '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@types/node@20.14.4)(@vitest/ui@1.6.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.4
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.8
+      magicast: 0.3.4
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.0.0
+      test-exclude: 6.0.0
+      vitest: 1.6.0(@types/node@20.14.4)(@vitest/ui@1.6.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@1.6.0':
     dependencies:
@@ -7932,6 +8011,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  istanbul-lib-source-maps@5.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-reports@3.1.7:
     dependencies:
       html-escaper: 2.0.2
@@ -8397,6 +8484,12 @@ snapshots:
   magic-string@0.30.8:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  magicast@0.3.4:
+    dependencies:
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
+      source-map-js: 1.2.0
 
   make-dir@4.0.0:
     dependencies:
@@ -8945,6 +9038,8 @@ snapshots:
 
   source-map-js@1.0.2: {}
 
+  source-map-js@1.2.0: {}
+
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
@@ -9192,6 +9287,17 @@ snapshots:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
+
+  typescript-eslint@7.13.1(eslint@8.57.0)(typescript@5.4.5):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.13.1(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.4.5: {}
 

--- a/specs/eslint/__snapshots__/config-snapshot.test.ts.snap
+++ b/specs/eslint/__snapshots__/config-snapshot.test.ts.snap
@@ -2170,13 +2170,13 @@ exports[`resolved config matches snapshot typescript.ts 1`] = `
   "ignorePatterns": [],
   "parser": "<OMITTED>",
   "parserOptions": {
+    "EXPERIMENTAL_useProjectService": true,
     "ecmaFeatures": {
       "generators": false,
       "jsx": true,
       "objectLiteralDuplicateProperties": false,
     },
     "ecmaVersion": "latest",
-    "project": true,
     "sourceType": "module",
   },
   "plugins": [
@@ -2184,6 +2184,7 @@ exports[`resolved config matches snapshot typescript.ts 1`] = `
     "unicorn",
     "simple-import-sort",
     "@typescript-eslint",
+    "@rightcapital",
   ],
   "reportUnusedDisableDirectives": true,
   "rules": {
@@ -2192,6 +2193,9 @@ exports[`resolved config matches snapshot typescript.ts 1`] = `
     ],
     "@babel/semi": [
       "off",
+    ],
+    "@rightcapital/no-explicit-type-on-function-component-identifier": [
+      "error",
     ],
     "@typescript-eslint/await-thenable": [
       "error",
@@ -4520,13 +4524,13 @@ exports[`resolved config matches snapshot typescript-react.tsx 1`] = `
   "ignorePatterns": [],
   "parser": "<OMITTED>",
   "parserOptions": {
+    "EXPERIMENTAL_useProjectService": true,
     "ecmaFeatures": {
       "generators": false,
       "jsx": true,
       "objectLiteralDuplicateProperties": false,
     },
     "ecmaVersion": "latest",
-    "project": true,
     "sourceType": "module",
   },
   "plugins": [
@@ -4678,6 +4682,9 @@ exports[`resolved config matches snapshot typescript-react.tsx 1`] = `
       "error",
     ],
     "@rightcapital/jsx-no-unused-expressions": [
+      "error",
+    ],
+    "@rightcapital/no-explicit-type-on-function-component-identifier": [
       "error",
     ],
     "@rightcapital/no-ignore-return-value-of-react-hooks": [

--- a/specs/eslint/package.json
+++ b/specs/eslint/package.json
@@ -25,6 +25,7 @@
     "eslint": "8.57.0",
     "execa": "9.2.0",
     "jest": "29.7.0",
-    "prettier": "3.3.2"
+    "prettier": "3.3.2",
+    "typescript-eslint": "7.13.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "files": [],
   "references": [
     { "path": "./tsconfig.scripts.json" },
     { "path": "./packages/eslint-plugin" },


### PR DESCRIPTION
1. Add Resolves https://github.com/RightCapitalHQ/frontend-style-guide/issues/150.
    Check the [test cases](https://github.com/RightCapitalHQ/frontend-style-guide/pull/151/files#diff-7625931aaba95d9fc7ddef164c32663c5b77ffc086a6d25f0d61c2036d374891) for examples.
3. Refactor existing rules to use `typescript-eslint` utils.
