### PR TITLE
refactor!: migrate from eslint-plugin-react to eslint-react

### DIFF
--- a/change/@rightcapital-eslint-config-typescript-react-51af7e30-c913-49c4-bb69-c7c8c0fbf666.json
+++ b/change/@rightcapital-eslint-config-typescript-react-51af7e30-c913-49c4-bb69-c7c8c0fbf666.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "refactor!: migrate from eslint-plugin-react to eslint-react",
+  "packageName": "@rightcapital/eslint-config-typescript-react",
+  "email": "38807139+liby@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-typescript-react/package.json
+++ b/packages/eslint-config-typescript-react/package.json
@@ -21,25 +21,25 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@eslint-react/eslint-plugin": "1.5.16",
     "@rightcapital/eslint-config-typescript": "workspace:*",
     "@rightcapital/eslint-plugin": "workspace:*",
     "@rushstack/eslint-patch": "1.10.3",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-jsx-a11y": "6.7.1",
-    "eslint-plugin-react": "7.34.2",
     "eslint-plugin-react-hooks": "4.6.2"
   },
   "devDependencies": {
     "@rightcapital/tsconfig": "workspace:*"
   },
   "peerDependencies": {
-    "eslint": "^8.23.1",
+    "eslint": "^8.57.0",
     "typescript": "^5.0.0"
   },
   "packageManager": "pnpm@9.4.0",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.18.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/eslint-config-typescript-react/src/index.ts
+++ b/packages/eslint-config-typescript-react/src/index.ts
@@ -4,25 +4,18 @@ require('@rushstack/eslint-patch/modern-module-resolution');
 
 const config: Linter.Config = {
   extends: [
-    require.resolve('eslint-config-airbnb/rules/react'),
-    require.resolve('eslint-config-airbnb/rules/react-a11y'),
-    require.resolve('eslint-config-airbnb/hooks'),
     require.resolve('@rightcapital/eslint-config-typescript'),
+    require.resolve('eslint-config-airbnb/hooks'),
+    require.resolve('eslint-config-airbnb/rules/react-a11y'),
     'plugin:@rightcapital/recommended-react',
+    'plugin:@eslint-react/recommended-legacy',
   ],
   plugins: ['@rightcapital'],
   reportUnusedDisableDirectives: true,
   rules: {
     'jsx-a11y/anchor-is-valid': 'off',
     'jsx-a11y/click-events-have-key-events': 'off',
-    'react/function-component-definition': 'off',
-    'react/jsx-filename-extension': ['warn', { extensions: ['.jsx', '.tsx'] }],
-    'react/jsx-key': ['error'],
-    'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
-    'react/jsx-uses-react': 'off',
-    'react/react-in-jsx-scope': 'off',
-    // We are using TypeScript, so it's not necessary to use React's defaultProps
-    'react/require-default-props': 'off',
+    '@eslint-react/no-useless-fragment': ['error'],
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
 
   packages/eslint-config-typescript-react:
     dependencies:
+      '@eslint-react/eslint-plugin':
+        specifier: 1.5.16
+        version: 1.5.16(eslint@8.57.0)(typescript@5.4.5)
       '@rightcapital/eslint-config-typescript':
         specifier: workspace:*
         version: link:../eslint-config-typescript
@@ -150,7 +153,7 @@ importers:
         specifier: 1.10.3
         version: 1.10.3
       eslint:
-        specifier: ^8.23.1
+        specifier: ^8.57.0
         version: 8.57.0
       eslint-config-airbnb:
         specifier: 19.0.4
@@ -161,9 +164,6 @@ importers:
       eslint-plugin-jsx-a11y:
         specifier: 6.7.1
         version: 6.7.1(eslint@8.57.0)
-      eslint-plugin-react:
-        specifier: 7.34.2
-        version: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: 4.6.2
         version: 4.6.2(eslint@8.57.0)
@@ -1277,6 +1277,37 @@ packages:
     resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint-react/ast@1.5.16':
+    resolution: {integrity: sha512-b6WwepSuyV8UNUojfsE/6TjfYcskGdlCXJfbgEtV+CYDclbBLSu7fhGYqSi0kRaG/UOcWSfj4OZ0/pw6hCV6RA==}
+
+  '@eslint-react/core@1.5.16':
+    resolution: {integrity: sha512-6zAf58toyDT7ZZc+2f7Cv8dSRy4TYv/JfL6GpwtM9FFMUsamlEGJBiaoNnV3U+gHZUyhuvYq42rV7nXegSlXdg==}
+
+  '@eslint-react/eslint-plugin@1.5.16':
+    resolution: {integrity: sha512-Ff/ZrElIEry1mzoZFhksHqej1zMaFLHR3ciFQoU4kQG8Xc4e5Y6I6WYi3ZT7Dcau1UZK+85sKYTVxSyOtDe5rQ==}
+    engines: {bun: '>=1.0.15', node: '>=18.18.0'}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: ^5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@eslint-react/jsx@1.5.16':
+    resolution: {integrity: sha512-IH+XX9c27ad4kMJhv40Za+PfswfPG93wOEF5+mDC9b1AxPcloPq2lc162NzWbiIHwKYAdHfIyDBY/6BTjXOgPA==}
+
+  '@eslint-react/shared@1.5.16':
+    resolution: {integrity: sha512-B45RP1yu2tA8RU3lvVu2ZiR3i2TSvOqcVBQm9S0QGfymI2eh54OcOfGdJWWF2lj11lw4H5vNksN1ZEHtCMypGA==}
+
+  '@eslint-react/tools@1.5.16':
+    resolution: {integrity: sha512-LSyj1KQZd6fDqBQPGfo8FHD3McWOsBndIONKELyx+w2KdPhk+ip4T3opAoAY45dngyG2Sf496GwPBz9VUhvSFA==}
+
+  '@eslint-react/types@1.5.16':
+    resolution: {integrity: sha512-9tLAzPU8KYNYUXQivudnngTnd3UnjfqgL4QeacsQrElWH2mE3ADDvyOImSyJ7k9DIJUUh2s3i/w618lBr7M4Eg==}
+
+  '@eslint-react/var@1.5.16':
+    resolution: {integrity: sha512-XTBQ329WViUCxaDxKTrNR3tMb9wYJatQiyNtMB7bAieDG50o9yO0npFse7T1U4ZDX2kaXA7plkeM0euWTriLVQ==}
+
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1543,9 +1574,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/node@20.14.2':
-    resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
 
   '@types/node@20.14.4':
     resolution: {integrity: sha512-1ChboN+57suCT2t/f8lwtPY/k3qTpuD/qnqQuYoBg6OQOcPyaw7PiZVdGpaZYAvhDDtqrt0oAaM8+oSu1xsUGw==}
@@ -2147,6 +2175,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge-ts@7.0.3:
+    resolution: {integrity: sha512-dxFbFO2RSIhPNBPL/j8Nvdt6/vrkW9+uGf1NLah/QxBGAVbK9fj2fGTO+HwdHpPAyFAsyT9iEn/1SI9SUvespw==}
+    engines: {node: '>=16.0.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -2383,11 +2415,51 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
 
+  eslint-plugin-react-core@1.5.16:
+    resolution: {integrity: sha512-BlBKgmfZ8N70nnEoFHmbuy/AN4eK9g6akBI+yhN2c3nSC0KojL96WKLvhIszV4du6h5ca3/3zjJMnCfQsyQuaQ==}
+    engines: {bun: '>=1.0.15', node: '>=18.18.0'}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: ^5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  eslint-plugin-react-dom@1.5.16:
+    resolution: {integrity: sha512-cDH7n8qDkqPoLQ4MChKxwssJyt+JhvkpeZP8SXwkgqAQp4nTvgAfZVTbW7aJ+IxorI4E+sWCVwVJa4HlvL5acQ==}
+    engines: {bun: '>=1.0.15', node: '>=18.18.0'}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: ^5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  eslint-plugin-react-hooks-extra@1.5.16:
+    resolution: {integrity: sha512-vgWEfYVqe5iJN0I/Cx1F+nKNn0oy1SXNCPCsIBkCx5xoIXPLA3FijhsyxS/9DEH62np9mlFxsd+KUIPEW5X20A==}
+    engines: {bun: '>=1.0.15', node: '>=18.18.0'}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: ^5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   eslint-plugin-react-hooks@4.6.2:
     resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+
+  eslint-plugin-react-naming-convention@1.5.16:
+    resolution: {integrity: sha512-7hsdfcQAKnizIM1sIzd3yuqMgA8vlMwnPAGFUe0xL5IZ2nBDYW243kXesuVlHuiMn0Y+iLSOC2CfXm4Pv9ip9Q==}
+    engines: {bun: '>=1.0.15', node: '>=18.18.0'}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: ^5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   eslint-plugin-react@7.34.2:
     resolution: {integrity: sha512-2HCmrU+/JNigDN6tg55cRDKCQWicYAPB38JGSFDQt95jDm8rrvSUo7YPkOIm5l6ts1j1zCvysNcasvfTMQzUOw==}
@@ -3349,6 +3421,9 @@ packages:
   merge@2.1.1:
     resolution: {integrity: sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==}
 
+  micro-memoize@4.1.2:
+    resolution: {integrity: sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g==}
+
   micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
@@ -3825,6 +3900,10 @@ packages:
   shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
 
+  short-unique-id@5.2.0:
+    resolution: {integrity: sha512-cMGfwNyfDZ/nzJ2k2M+ClthBIh//GlZl1JEf47Uoa9XR11bz8Pa2T2wQO4bVrRdH48LrIDWJahQziKo3MjhsWg==}
+    hasBin: true
+
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
@@ -3907,6 +3986,9 @@ packages:
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
+
+  string-ts@2.1.1:
+    resolution: {integrity: sha512-BtSlY8ttfj+veJuirU5uOP7pxqIuGQHzPSNZS7Kj3orT8250GBijUYp0K5ZV+s5OREMsC1TLaSVB75kyeBYZyw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4046,6 +4128,9 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-pattern@5.2.0:
+    resolution: {integrity: sha512-aGaSpOlDcns7ZoeG/OMftWyQG1KqPVhgplhJxNCvyIXqWrumM5uIoOSarw/hmmi/T1PnuQ/uD8NaFHvLpHicDg==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -4183,6 +4268,9 @@ packages:
   v8-to-istanbul@9.2.0:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
+
+  valibot@0.32.0:
+    resolution: {integrity: sha512-FXBnJl4bNOmeg7lQv+jfvo/wADsRBN8e9C3r+O77Re3dEnDma8opp7p4hcIbF7XJJ30h/5SVohdjer17/sHOsQ==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -5432,6 +5520,113 @@ snapshots:
 
   '@eslint-community/regexpp@4.10.0': {}
 
+  '@eslint-react/ast@1.5.16(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      string-ts: 2.1.1
+      ts-pattern: 5.2.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
+  '@eslint-react/core@1.5.16(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-react/ast': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/jsx': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/shared': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/var': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/type-utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      short-unique-id: 5.2.0
+      ts-pattern: 5.2.0
+      valibot: 0.32.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
+  '@eslint-react/eslint-plugin@1.5.16(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-react/shared': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/type-utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      eslint-plugin-react-core: 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      eslint-plugin-react-dom: 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      eslint-plugin-react-hooks-extra: 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      eslint-plugin-react-naming-convention: 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint-react/jsx@1.5.16(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-react/ast': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/shared': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/var': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      micro-memoize: 4.1.2
+      ts-pattern: 5.2.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
+  '@eslint-react/shared@1.5.16(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      deepmerge-ts: 7.0.3
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
+  '@eslint-react/tools@1.5.16': {}
+
+  '@eslint-react/types@1.5.16(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-react/tools': 1.5.16
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
+  '@eslint-react/var@1.5.16(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-react/ast': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      string-ts: 2.1.1
+      valibot: 0.32.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
@@ -5789,10 +5984,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
-
-  '@types/node@20.14.2':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@20.14.4':
     dependencies:
@@ -6545,6 +6736,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge-ts@7.0.3: {}
+
   deepmerge@4.3.1: {}
 
   defaults@1.0.4:
@@ -6925,9 +7118,92 @@ snapshots:
       object.fromentries: 2.0.8
       semver: 6.3.1
 
+  eslint-plugin-react-core@1.5.16(eslint@8.57.0)(typescript@5.4.5):
+    dependencies:
+      '@eslint-react/ast': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/core': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/jsx': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/shared': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/var': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/type-utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      string-ts: 2.1.1
+      ts-api-utils: 1.3.0(typescript@5.4.5)
+      valibot: 0.32.0
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-react-dom@1.5.16(eslint@8.57.0)(typescript@5.4.5):
+    dependencies:
+      '@eslint-react/ast': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/core': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/jsx': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/shared': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/var': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      string-ts: 2.1.1
+      valibot: 0.32.0
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-react-hooks-extra@1.5.16(eslint@8.57.0)(typescript@5.4.5):
+    dependencies:
+      '@eslint-react/ast': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/core': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/jsx': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/shared': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/var': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/type-utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      string-ts: 2.1.1
+      valibot: 0.32.0
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react-hooks@4.6.2(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
+
+  eslint-plugin-react-naming-convention@1.5.16(eslint@8.57.0)(typescript@5.4.5):
+    dependencies:
+      '@eslint-react/ast': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/core': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/jsx': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/shared': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-react/tools': 1.5.16
+      '@eslint-react/types': 1.5.16(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/type-utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      string-ts: 2.1.1
+      valibot: 0.32.0
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.34.2(eslint@8.57.0):
     dependencies:
@@ -8140,6 +8416,8 @@ snapshots:
 
   merge@2.1.1: {}
 
+  micro-memoize@4.1.2: {}
+
   micromatch@4.0.5:
     dependencies:
       braces: 3.0.2
@@ -8625,6 +8903,8 @@ snapshots:
 
   shell-quote@1.8.1: {}
 
+  short-unique-id@5.2.0: {}
+
   side-channel@1.0.6:
     dependencies:
       call-bind: 1.0.7
@@ -8704,6 +8984,8 @@ snapshots:
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
+
+  string-ts@2.1.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -8834,6 +9116,8 @@ snapshots:
     dependencies:
       typescript: 5.4.5
 
+  ts-pattern@5.2.0: {}
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -8962,6 +9246,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  valibot@0.32.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/specs/eslint/__snapshots__/config-snapshot.test.ts.snap
+++ b/specs/eslint/__snapshots__/config-snapshot.test.ts.snap
@@ -4530,13 +4530,14 @@ exports[`resolved config matches snapshot typescript-react.tsx 1`] = `
     "sourceType": "module",
   },
   "plugins": [
-    "react",
-    "jsx-a11y",
-    "react-hooks",
     "import",
     "unicorn",
     "simple-import-sort",
     "@typescript-eslint",
+    "react-hooks",
+    "react",
+    "jsx-a11y",
+    "@eslint-react",
     "@rightcapital",
   ],
   "reportUnusedDisableDirectives": true,
@@ -4546,6 +4547,135 @@ exports[`resolved config matches snapshot typescript-react.tsx 1`] = `
     ],
     "@babel/semi": [
       "off",
+    ],
+    "@eslint-react/dom/no-children-in-void-dom-elements": [
+      "warn",
+    ],
+    "@eslint-react/dom/no-dangerously-set-innerhtml": [
+      "warn",
+    ],
+    "@eslint-react/dom/no-dangerously-set-innerhtml-with-children": [
+      "error",
+    ],
+    "@eslint-react/dom/no-find-dom-node": [
+      "error",
+    ],
+    "@eslint-react/dom/no-missing-button-type": [
+      "warn",
+    ],
+    "@eslint-react/dom/no-missing-iframe-sandbox": [
+      "warn",
+    ],
+    "@eslint-react/dom/no-namespace": [
+      "error",
+    ],
+    "@eslint-react/dom/no-render-return-value": [
+      "error",
+    ],
+    "@eslint-react/dom/no-script-url": [
+      "warn",
+    ],
+    "@eslint-react/dom/no-unsafe-iframe-sandbox": [
+      "warn",
+    ],
+    "@eslint-react/dom/no-unsafe-target-blank": [
+      "warn",
+    ],
+    "@eslint-react/ensure-forward-ref-using-ref": [
+      "warn",
+    ],
+    "@eslint-react/no-access-state-in-setstate": [
+      "error",
+    ],
+    "@eslint-react/no-array-index-key": [
+      "warn",
+    ],
+    "@eslint-react/no-children-count": [
+      "warn",
+    ],
+    "@eslint-react/no-children-for-each": [
+      "warn",
+    ],
+    "@eslint-react/no-children-map": [
+      "warn",
+    ],
+    "@eslint-react/no-children-only": [
+      "warn",
+    ],
+    "@eslint-react/no-children-prop": [
+      "warn",
+    ],
+    "@eslint-react/no-children-to-array": [
+      "warn",
+    ],
+    "@eslint-react/no-clone-element": [
+      "warn",
+    ],
+    "@eslint-react/no-comment-textnodes": [
+      "warn",
+    ],
+    "@eslint-react/no-component-will-mount": [
+      "error",
+    ],
+    "@eslint-react/no-component-will-receive-props": [
+      "error",
+    ],
+    "@eslint-react/no-component-will-update": [
+      "error",
+    ],
+    "@eslint-react/no-create-ref": [
+      "error",
+    ],
+    "@eslint-react/no-direct-mutation-state": [
+      "error",
+    ],
+    "@eslint-react/no-duplicate-key": [
+      "error",
+    ],
+    "@eslint-react/no-missing-key": [
+      "error",
+    ],
+    "@eslint-react/no-nested-components": [
+      "warn",
+    ],
+    "@eslint-react/no-redundant-should-component-update": [
+      "error",
+    ],
+    "@eslint-react/no-set-state-in-component-did-mount": [
+      "warn",
+    ],
+    "@eslint-react/no-set-state-in-component-did-update": [
+      "warn",
+    ],
+    "@eslint-react/no-set-state-in-component-will-update": [
+      "warn",
+    ],
+    "@eslint-react/no-string-refs": [
+      "error",
+    ],
+    "@eslint-react/no-unsafe-component-will-mount": [
+      "warn",
+    ],
+    "@eslint-react/no-unsafe-component-will-receive-props": [
+      "warn",
+    ],
+    "@eslint-react/no-unsafe-component-will-update": [
+      "warn",
+    ],
+    "@eslint-react/no-unstable-context-value": [
+      "error",
+    ],
+    "@eslint-react/no-unstable-default-props": [
+      "error",
+    ],
+    "@eslint-react/no-unused-class-component-members": [
+      "warn",
+    ],
+    "@eslint-react/no-unused-state": [
+      "warn",
+    ],
+    "@eslint-react/no-useless-fragment": [
+      "error",
     ],
     "@rightcapital/jsx-no-unused-expressions": [
       "error",
@@ -6720,522 +6850,53 @@ exports[`resolved config matches snapshot typescript-react.tsx 1`] = `
     "react-hooks/rules-of-hooks": [
       "error",
     ],
-    "react/boolean-prop-naming": [
-      "off",
-      {
-        "message": "",
-        "propTypeNames": [
-          "bool",
-          "mutuallyExclusiveTrueProps",
-        ],
-        "rule": "^(is|has)[A-Z]([A-Za-z0-9]?)+",
-      },
-    ],
-    "react/button-has-type": [
-      "error",
-      {
-        "button": true,
-        "reset": false,
-        "submit": true,
-      },
-    ],
-    "react/default-props-match-prop-types": [
-      "error",
-      {
-        "allowRequiredDefaults": false,
-      },
-    ],
-    "react/destructuring-assignment": [
-      "error",
-      "always",
-    ],
-    "react/display-name": [
-      "off",
-      {
-        "ignoreTranspilerName": false,
-      },
-    ],
-    "react/forbid-component-props": [
-      "off",
-      {
-        "forbid": [],
-      },
-    ],
-    "react/forbid-dom-props": [
-      "off",
-      {
-        "forbid": [],
-      },
-    ],
-    "react/forbid-elements": [
-      "off",
-      {
-        "forbid": [],
-      },
-    ],
-    "react/forbid-foreign-prop-types": [
-      "warn",
-      {
-        "allowInPropTypes": true,
-      },
-    ],
-    "react/forbid-prop-types": [
-      "error",
-      {
-        "checkChildContextTypes": true,
-        "checkContextTypes": true,
-        "forbid": [
-          "any",
-          "array",
-          "object",
-        ],
-      },
-    ],
-    "react/function-component-definition": [
-      "off",
-      {
-        "namedComponents": [
-          "function-declaration",
-          "function-expression",
-        ],
-        "unnamedComponents": "function-expression",
-      },
-    ],
-    "react/jsx-boolean-value": [
-      "error",
-      "never",
-      {
-        "always": [],
-      },
-    ],
     "react/jsx-child-element-spacing": [
       "off",
     ],
     "react/jsx-closing-bracket-location": [
       "off",
-      "line-aligned",
     ],
     "react/jsx-closing-tag-location": [
       "off",
     ],
-    "react/jsx-curly-brace-presence": [
-      "error",
-      {
-        "children": "never",
-        "props": "never",
-      },
-    ],
     "react/jsx-curly-newline": [
       "off",
-      {
-        "multiline": "consistent",
-        "singleline": "consistent",
-      },
     ],
     "react/jsx-curly-spacing": [
       "off",
-      "never",
-      {
-        "allowMultiline": true,
-      },
     ],
     "react/jsx-equals-spacing": [
       "off",
-      "never",
-    ],
-    "react/jsx-filename-extension": [
-      "warn",
-      {
-        "extensions": [
-          ".jsx",
-          ".tsx",
-        ],
-      },
     ],
     "react/jsx-first-prop-new-line": [
       "off",
-      "multiline-multiprop",
-    ],
-    "react/jsx-fragments": [
-      "error",
-      "syntax",
-    ],
-    "react/jsx-handler-names": [
-      "off",
-      {
-        "eventHandlerPrefix": "handle",
-        "eventHandlerPropPrefix": "on",
-      },
     ],
     "react/jsx-indent": [
       "off",
-      2,
     ],
     "react/jsx-indent-props": [
-      "off",
-      2,
-    ],
-    "react/jsx-key": [
-      "error",
-    ],
-    "react/jsx-max-depth": [
       "off",
     ],
     "react/jsx-max-props-per-line": [
       "off",
-      {
-        "maximum": 1,
-        "when": "multiline",
-      },
     ],
     "react/jsx-newline": [
       "off",
     ],
-    "react/jsx-no-bind": [
-      "error",
-      {
-        "allowArrowFunctions": true,
-        "allowBind": false,
-        "allowFunctions": false,
-        "ignoreDOMComponents": true,
-        "ignoreRefs": true,
-      },
-    ],
-    "react/jsx-no-comment-textnodes": [
-      "error",
-    ],
-    "react/jsx-no-constructed-context-values": [
-      "error",
-    ],
-    "react/jsx-no-duplicate-props": [
-      "error",
-      {
-        "ignoreCase": true,
-      },
-    ],
-    "react/jsx-no-literals": [
-      "off",
-      {
-        "noStrings": true,
-      },
-    ],
-    "react/jsx-no-script-url": [
-      "error",
-      [
-        {
-          "name": "Link",
-          "props": [
-            "to",
-          ],
-        },
-      ],
-    ],
-    "react/jsx-no-target-blank": [
-      "error",
-      {
-        "enforceDynamicLinks": "always",
-        "forms": false,
-        "links": true,
-      },
-    ],
-    "react/jsx-no-undef": [
-      "error",
-    ],
-    "react/jsx-no-useless-fragment": [
-      "error",
-      {
-        "allowExpressions": true,
-      },
-    ],
     "react/jsx-one-expression-per-line": [
       "off",
-      {
-        "allow": "single-child",
-      },
-    ],
-    "react/jsx-pascal-case": [
-      "error",
-      {
-        "allowAllCaps": true,
-        "ignore": [],
-      },
     ],
     "react/jsx-props-no-multi-spaces": [
       "off",
     ],
-    "react/jsx-props-no-spreading": [
-      "error",
-      {
-        "custom": "enforce",
-        "exceptions": [],
-        "explicitSpread": "ignore",
-        "html": "enforce",
-      },
-    ],
-    "react/jsx-sort-default-props": [
-      "off",
-      {
-        "ignoreCase": true,
-      },
-    ],
-    "react/jsx-sort-prop-types": [
-      "off",
-    ],
-    "react/jsx-sort-props": [
-      "off",
-      {
-        "callbacksLast": false,
-        "ignoreCase": true,
-        "noSortAlphabetically": false,
-        "reservedFirst": true,
-        "shorthandFirst": false,
-        "shorthandLast": false,
-      },
-    ],
     "react/jsx-space-before-closing": [
       "off",
-      "always",
     ],
     "react/jsx-tag-spacing": [
       "off",
-      {
-        "afterOpening": "never",
-        "beforeClosing": "never",
-        "beforeSelfClosing": "always",
-        "closingSlash": "never",
-      },
-    ],
-    "react/jsx-uses-react": [
-      "off",
-    ],
-    "react/jsx-uses-vars": [
-      "error",
     ],
     "react/jsx-wrap-multilines": [
       "off",
-      {
-        "arrow": "parens-new-line",
-        "assignment": "parens-new-line",
-        "condition": "parens-new-line",
-        "declaration": "parens-new-line",
-        "logical": "parens-new-line",
-        "prop": "parens-new-line",
-        "return": "parens-new-line",
-      },
-    ],
-    "react/no-access-state-in-setstate": [
-      "error",
-    ],
-    "react/no-adjacent-inline-elements": [
-      "off",
-    ],
-    "react/no-array-index-key": [
-      "error",
-    ],
-    "react/no-arrow-function-lifecycle": [
-      "error",
-    ],
-    "react/no-children-prop": [
-      "error",
-    ],
-    "react/no-danger": [
-      "warn",
-    ],
-    "react/no-danger-with-children": [
-      "error",
-    ],
-    "react/no-deprecated": [
-      "error",
-    ],
-    "react/no-did-mount-set-state": [
-      "off",
-    ],
-    "react/no-did-update-set-state": [
-      "error",
-    ],
-    "react/no-direct-mutation-state": [
-      "off",
-    ],
-    "react/no-find-dom-node": [
-      "error",
-    ],
-    "react/no-invalid-html-attribute": [
-      "error",
-    ],
-    "react/no-is-mounted": [
-      "error",
-    ],
-    "react/no-multi-comp": [
-      "off",
-    ],
-    "react/no-namespace": [
-      "error",
-    ],
-    "react/no-redundant-should-component-update": [
-      "error",
-    ],
-    "react/no-render-return-value": [
-      "error",
-    ],
-    "react/no-set-state": [
-      "off",
-    ],
-    "react/no-string-refs": [
-      "error",
-    ],
-    "react/no-this-in-sfc": [
-      "error",
-    ],
-    "react/no-typos": [
-      "error",
-    ],
-    "react/no-unescaped-entities": [
-      "error",
-    ],
-    "react/no-unknown-property": [
-      "error",
-    ],
-    "react/no-unsafe": [
-      "off",
-    ],
-    "react/no-unstable-nested-components": [
-      "error",
-    ],
-    "react/no-unused-class-component-methods": [
-      "error",
-    ],
-    "react/no-unused-prop-types": [
-      "error",
-      {
-        "customValidators": [],
-        "skipShapeProps": true,
-      },
-    ],
-    "react/no-unused-state": [
-      "error",
-    ],
-    "react/no-will-update-set-state": [
-      "error",
-    ],
-    "react/prefer-es6-class": [
-      "error",
-      "always",
-    ],
-    "react/prefer-exact-props": [
-      "error",
-    ],
-    "react/prefer-read-only-props": [
-      "off",
-    ],
-    "react/prefer-stateless-function": [
-      "error",
-      {
-        "ignorePureComponents": true,
-      },
-    ],
-    "react/prop-types": [
-      "error",
-      {
-        "customValidators": [],
-        "ignore": [],
-        "skipUndeclared": false,
-      },
-    ],
-    "react/react-in-jsx-scope": [
-      "off",
-    ],
-    "react/require-default-props": [
-      "off",
-      {
-        "forbidDefaultForRequired": true,
-      },
-    ],
-    "react/require-optimization": [
-      "off",
-      {
-        "allowDecorators": [],
-      },
-    ],
-    "react/require-render-return": [
-      "error",
-    ],
-    "react/self-closing-comp": [
-      "error",
-    ],
-    "react/sort-comp": [
-      "error",
-      {
-        "groups": {
-          "lifecycle": [
-            "displayName",
-            "propTypes",
-            "contextTypes",
-            "childContextTypes",
-            "mixins",
-            "statics",
-            "defaultProps",
-            "constructor",
-            "getDefaultProps",
-            "getInitialState",
-            "state",
-            "getChildContext",
-            "getDerivedStateFromProps",
-            "componentWillMount",
-            "UNSAFE_componentWillMount",
-            "componentDidMount",
-            "componentWillReceiveProps",
-            "UNSAFE_componentWillReceiveProps",
-            "shouldComponentUpdate",
-            "componentWillUpdate",
-            "UNSAFE_componentWillUpdate",
-            "getSnapshotBeforeUpdate",
-            "componentDidUpdate",
-            "componentDidCatch",
-            "componentWillUnmount",
-          ],
-          "rendering": [
-            "/^render.+$/",
-            "render",
-          ],
-        },
-        "order": [
-          "static-variables",
-          "static-methods",
-          "instance-variables",
-          "lifecycle",
-          "/^handle.+$/",
-          "/^on.+$/",
-          "getters",
-          "setters",
-          "/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/",
-          "instance-methods",
-          "everything-else",
-          "rendering",
-        ],
-      },
-    ],
-    "react/sort-prop-types": [
-      "off",
-      {
-        "callbacksLast": false,
-        "ignoreCase": true,
-        "requiredFirst": false,
-        "sortShapeProp": true,
-      },
-    ],
-    "react/state-in-constructor": [
-      "error",
-      "always",
-    ],
-    "react/static-property-placement": [
-      "error",
-      "property assignment",
-    ],
-    "react/style-prop-object": [
-      "error",
-    ],
-    "react/void-dom-elements-no-children": [
-      "error",
     ],
     "require-atomic-updates": [
       "off",
@@ -7611,15 +7272,6 @@ exports[`resolved config matches snapshot typescript-react.tsx 1`] = `
       "typescript": {
         "alwaysTryTypes": true,
       },
-    },
-    "propWrapperFunctions": [
-      "forbidExtraProps",
-      "exact",
-      "Object.freeze",
-    ],
-    "react": {
-      "pragma": "React",
-      "version": "detect",
     },
   },
 }


### PR DESCRIPTION
## Description

Solve https://github.com/RightCapitalHQ/frontend-style-guide/issues/156

[[Rule Migration] migrate eslint-plugin-react rules](https://github.com/Rel1cx/eslint-react/issues/85).