### PR TITLE
test: correct the misupdated test snapshot

### DIFF
--- a/specs/eslint/__snapshots__/config-snapshot.test.ts.snap
+++ b/specs/eslint/__snapshots__/config-snapshot.test.ts.snap
@@ -4539,6 +4539,7 @@ exports[`resolved config matches snapshot > typescript-react.tsx 1`] = `
     "simple-import-sort",
     "@typescript-eslint",
     "react-hooks",
+    "react",
     "jsx-a11y",
     "@eslint-react",
     "@rightcapital",


### PR DESCRIPTION
The `react` plugin was present in the `typescript-react` snapshot, but we missed it during the migration to Vitest snapshots.

reference: https://github.com/RightCapitalHQ/frontend-style-guide/blob/ea2deb21fd7c7f5041734689d38b1a8ec3eb1d0b/specs/eslint/__snapshots__/config-snapshot.test.ts.snap#L4542