### PR TITLE
Migrate to eslint-plugin-import-x

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,7 +15,7 @@ module.exports = {
       env: { node: true, commonjs: true },
       rules: {
         'no-unused-expressions': ['error', { allowTaggedTemplates: true }],
-        'import/no-extraneous-dependencies': 'off',
+        'import-x/no-extraneous-dependencies': 'off',
         'no-console': 'off',
         'no-void': ['error', { allowAsStatement: true }],
       },
@@ -30,7 +30,7 @@ module.exports = {
       extends: '@rightcapital/typescript',
       rules: {
         'no-unused-expressions': ['error', { allowTaggedTemplates: true }],
-        'import/no-extraneous-dependencies': 'off',
+        'import-x/no-extraneous-dependencies': 'off',
         'no-console': 'off',
         'no-void': ['error', { allowAsStatement: true }],
       },

--- a/change/@rightcapital-eslint-config-base-865f1e50-9b72-4469-9354-afb65e9ef018.json
+++ b/change/@rightcapital-eslint-config-base-865f1e50-9b72-4469-9354-afb65e9ef018.json
@@ -1,0 +1,7 @@
+{
+  "comment": "feat: migrate to eslint-plugin-import-x",
+  "type": "minor",
+  "packageName": "@rightcapital/eslint-config-base",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/change/@rightcapital-eslint-config-typescript-3ed790b9-d5eb-43b4-b037-a4dca0e62d71.json
+++ b/change/@rightcapital-eslint-config-typescript-3ed790b9-d5eb-43b4-b037-a4dca0e62d71.json
@@ -1,0 +1,7 @@
+{
+  "comment": "feat: migrate to eslint-plugin-import-x",
+  "type": "minor",
+  "packageName": "@rightcapital/eslint-config-typescript",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/change/@rightcapital-lint-eslint-config-rules-03d5d202-d451-4974-b88c-90f5f1316bd6.json
+++ b/change/@rightcapital-lint-eslint-config-rules-03d5d202-d451-4974-b88c-90f5f1316bd6.json
@@ -1,0 +1,7 @@
+{
+  "comment": "feat: migrate to eslint-plugin-import-x",
+  "type": "minor",
+  "packageName": "@rightcapital/lint-eslint-config-rules",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -26,7 +26,7 @@
     "@stylistic/eslint-plugin-js": "2.8.0",
     "confusing-browser-globals": "1.0.11",
     "eslint-import-resolver-typescript": "3.6.1",
-    "eslint-plugin-import": "npm:eslint-plugin-i@2.29.1",
+    "eslint-plugin-import-x": "4.3.1",
     "eslint-plugin-lodash": "8.0.0",
     "eslint-plugin-n": "17.10.2",
     "eslint-plugin-simple-import-sort": "12.1.1",
@@ -38,7 +38,7 @@
     "@types/semver": "7.5.8"
   },
   "peerDependencies": {
-    "eslint": "^8.23.1"
+    "eslint": "^8.23.1 || ^9.0.0"
   },
   "packageManager": "pnpm@9.10.0",
   "engines": {

--- a/packages/eslint-config-base/src/rules/imports.ts
+++ b/packages/eslint-config-base/src/rules/imports.ts
@@ -3,17 +3,16 @@ import type { Linter } from 'eslint';
 // extracted from eslint-config-airbnb-base@15.0.0
 // https://github.com/airbnb/javascript/blob/eslint-config-airbnb-base-v15.0.0/packages/eslint-config-airbnb-base/rules/imports.js
 const config: Linter.Config = {
-  plugins: ['import', 'simple-import-sort'],
+  plugins: ['import-x', 'simple-import-sort'],
   settings: {
-    'import/resolver': {
+    'import-x/resolver': {
       node: {
         extensions: ['.mjs', '.js', '.json'],
       },
       typescript: {},
     },
-    'import/extensions': ['.js', '.mjs', '.jsx'],
-    'import/core-modules': [],
-    'import/ignore': [
+    'import-x/extensions': ['.js', '.mjs', '.jsx'],
+    'import-x/ignore': [
       'node_modules',
       '\\.(coffee|scss|css|less|hbs|svg|json)$',
     ],
@@ -23,31 +22,34 @@ const config: Linter.Config = {
     // Static analysis:
 
     // ensure imports point to files/modules that can be resolved
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
-    'import/no-unresolved': ['error', { commonjs: true, caseSensitive: true }],
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-unresolved.md
+    'import-x/no-unresolved': [
+      'error',
+      { commonjs: true, caseSensitive: true },
+    ],
 
     // ensure named imports coupled with named exports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md#when-not-to-use-it
-    'import/named': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/named.md
+    'import-x/named': 'error',
 
     // Helpful warnings:
 
     // disallow invalid exports, e.g. multiple defaults
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
-    'import/export': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/export.md
+    'import-x/export': 'error',
 
     // do not allow a default import name to match a named export
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
-    'import/no-named-as-default': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-named-as-default.md
+    'import-x/no-named-as-default': 'error',
 
     // warn on accessing default export property names that are also named exports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md
-    'import/no-named-as-default-member': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-named-as-default-member.md
+    'import-x/no-named-as-default-member': 'error',
 
     // Forbid the use of extraneous packages
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-extraneous-dependencies.md
     // paths are treated both as absolute paths, and relative to process.cwd()
-    'import/no-extraneous-dependencies': [
+    'import-x/no-extraneous-dependencies': [
       'error',
       {
         /**
@@ -87,22 +89,22 @@ const config: Linter.Config = {
     ],
 
     // Forbid mutable exports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md
-    'import/no-mutable-exports': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-mutable-exports.md
+    'import-x/no-mutable-exports': 'error',
 
     // Style guide:
 
     // disallow non-import statements appearing before import statements
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
-    'import/first': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/first.md
+    'import-x/first': 'error',
 
     // disallow duplicate imports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
-    'import/no-duplicates': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-duplicates.md
+    'import-x/no-duplicates': 'error',
 
     // Ensure consistent use of file extension within the import path
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
-    'import/extensions': [
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/extensions.md
+    'import-x/extensions': [
       'warn',
       'ignorePackages',
       {
@@ -115,8 +117,8 @@ const config: Linter.Config = {
 
     // Ensure all imports are sorted
     // https://github.com/lydell/eslint-plugin-simple-import-sort?tab=readme-ov-file#usage
-    // MEMO: simple-import-sort/imports should not be used with import/order
-    'import/order': 'off',
+    // MEMO: simple-import-sort/imports should not be used with import-x/order
+    'import-x/order': 'off',
     'simple-import-sort/imports': 'error',
 
     // Ensure all exports are sorted
@@ -124,44 +126,44 @@ const config: Linter.Config = {
     'simple-import-sort/exports': 'error',
 
     // Require a newline after the last import/require in a group
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md
-    'import/newline-after-import': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/newline-after-import.md
+    'import-x/newline-after-import': 'error',
 
     // Forbid modules to have too many dependencies
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/max-dependencies.md
-    'import/max-dependencies': ['off', { max: 10 }],
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/max-dependencies.md
+    'import-x/max-dependencies': ['off', { max: 10 }],
 
     // Forbid import of modules using absolute paths
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md
-    'import/no-absolute-path': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-absolute-path.md
+    'import-x/no-absolute-path': 'error',
 
     // Forbid require() calls with expressions
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md
-    'import/no-dynamic-require': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-dynamic-require.md
+    'import-x/no-dynamic-require': 'error',
 
     // Forbid Webpack loader syntax in imports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
-    'import/no-webpack-loader-syntax': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-webpack-loader-syntax.md
+    'import-x/no-webpack-loader-syntax': 'error',
 
     // Prevent importing the default as if it were named
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md
-    'import/no-named-default': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-named-default.md
+    'import-x/no-named-default': 'error',
 
     // Forbid a module from importing itself
-    // https://github.com/benmosher/eslint-plugin-import/blob/44a038c06487964394b1e15b64f3bd34e5d40cde/docs/rules/no-self-import.md
-    'import/no-self-import': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-self-import.md
+    'import-x/no-self-import': 'error',
 
     // Forbid cyclical dependencies between modules
-    // https://github.com/benmosher/eslint-plugin-import/blob/d81f48a2506182738409805f5272eff4d77c9348/docs/rules/no-cycle.md
-    'import/no-cycle': ['error', { maxDepth: '∞' }],
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-cycle.md
+    'import-x/no-cycle': 'error',
 
     // Ensures that there are no useless path segments
-    // https://github.com/benmosher/eslint-plugin-import/blob/ebafcbf59ec9f653b2ac2a0156ca3bcba0a7cf57/docs/rules/no-useless-path-segments.md
-    'import/no-useless-path-segments': ['error', { commonjs: true }],
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-useless-path-segments.md
+    'import-x/no-useless-path-segments': ['error', { commonjs: true }],
 
     // Reports the use of import declarations with CommonJS exports in any module except for the main module.
-    // https://github.com/benmosher/eslint-plugin-import/blob/1012eb951767279ce3b540a4ec4f29236104bb5b/docs/rules/no-import-module-exports.md
-    'import/no-import-module-exports': [
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-import-module-exports.md
+    'import-x/no-import-module-exports': [
       'error',
       {
         exceptions: [],
@@ -169,8 +171,8 @@ const config: Linter.Config = {
     ],
 
     // Use this rule to prevent importing packages through relative paths.
-    // https://github.com/benmosher/eslint-plugin-import/blob/1012eb951767279ce3b540a4ec4f29236104bb5b/docs/rules/no-relative-packages.md
-    'import/no-relative-packages': 'error',
+    // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-relative-packages.md
+    'import-x/no-relative-packages': 'error',
   },
 };
 

--- a/packages/eslint-config-typescript/src/index.ts
+++ b/packages/eslint-config-typescript/src/index.ts
@@ -14,10 +14,10 @@ const config: Linter.Config = {
     projectService: true,
   },
   settings: {
-    'import/parsers': {
+    'import-x/parsers': {
       '@typescript-eslint/parser': ['.ts', '.cts', '.mts', '.tsx'],
     },
-    'import/resolver': {
+    'import-x/resolver': {
       typescript: { alwaysTryTypes: true },
     },
   },
@@ -113,7 +113,7 @@ const config: Linter.Config = {
       { fixMixedExportsWithInlineTypeSpecifier: true },
     ],
     '@typescript-eslint/no-import-type-side-effects': 'error',
-    'import/no-duplicates': ['error', { 'prefer-inline': true }],
+    'import-x/no-duplicates': ['error', { 'prefer-inline': true }],
     '@rightcapital/no-explicit-type-on-function-component-identifier': 'error',
 
     /**

--- a/packages/lint-eslint-config-rules/src/index.ts
+++ b/packages/lint-eslint-config-rules/src/index.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import/extensions
+// eslint-disable-next-line import-x/extensions
 import 'core-js/es/set/index.js'; // for Node.js <22.0.0
 
 import { cpus } from 'node:os';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,14 +75,14 @@ importers:
         specifier: 1.0.11
         version: 1.0.11
       eslint:
-        specifier: ^8.23.1
+        specifier: ^8.23.1 || ^9.0.0
         version: 8.57.1
       eslint-import-resolver-typescript:
         specifier: 3.6.1
-        version: 3.6.1(eslint-plugin-i@2.29.1)(eslint@8.57.1)
-      eslint-plugin-import:
-        specifier: npm:eslint-plugin-i@2.29.1
-        version: eslint-plugin-i@2.29.1(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+        version: 3.6.1(eslint-plugin-import@2.30.0)(eslint@8.57.1)
+      eslint-plugin-import-x:
+        specifier: 4.3.1
+        version: 4.3.1(eslint@8.57.1)(typescript@5.6.2)
       eslint-plugin-lodash:
         specifier: 8.0.0
         version: 8.0.0(eslint@8.57.1)
@@ -994,6 +994,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
   '@rushstack/eslint-patch@1.10.4':
     resolution: {integrity: sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==}
 
@@ -1036,6 +1039,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
   '@types/node@20.16.5':
     resolution: {integrity: sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==}
@@ -1300,6 +1306,10 @@ packages:
 
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlastindex@1.2.5:
+    resolution: {integrity: sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==}
     engines: {node: '>= 0.4'}
 
   array.prototype.flat@1.3.2:
@@ -1758,6 +1768,27 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
 
+  eslint-module-utils@2.11.1:
+    resolution: {integrity: sha512-EwcbfLOhwVMAfatfqLecR2yv3dE5+kQ8kx+Rrt0DvDXEVwW86KQ/xbMDQhtp5l42VXukD5SOF8mQQHbaNtO0CQ==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
   eslint-module-utils@2.8.2:
     resolution: {integrity: sha512-3XnC5fDyc8M4J2E8pt8pmSVRX2M+5yWMCfI/kDZwauQeFgzQOuhcRBFKjTeJagqgk4sFKxe1mvNVnaWwImx/Tg==}
     engines: {node: '>=4'}
@@ -1791,11 +1822,21 @@ packages:
     peerDependencies:
       eslint: '>=8.23.0'
 
-  eslint-plugin-i@2.29.1:
-    resolution: {integrity: sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==}
-    engines: {node: '>=12'}
+  eslint-plugin-import-x@4.3.1:
+    resolution: {integrity: sha512-5TriWkXulDl486XnYYRgsL+VQoS/7mhN/2ci02iLCuL7gdhbiWxnsuL/NTcaKY9fpMgsMFjWZBtIGW7pb+RX0g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^7.2.0 || ^8
+      eslint: ^8.57.0 || ^9.0.0
+
+  eslint-plugin-import@2.30.0:
+    resolution: {integrity: sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
 
   eslint-plugin-jsx-a11y@6.7.1:
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
@@ -2508,6 +2549,10 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
@@ -2725,6 +2770,10 @@ packages:
 
   object.fromentries@2.0.8:
     resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
     engines: {node: '>= 0.4'}
 
   object.values@1.2.0:
@@ -3115,6 +3164,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stable-hash@0.0.4:
+    resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -3160,6 +3212,10 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
 
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -3277,6 +3333,9 @@ packages:
 
   ts-pattern@5.3.1:
     resolution: {integrity: sha512-1RUMKa8jYQdNfmnK4jyzBK3/PS/tnjcZ1CW0v1vWDeYe5RBklc/nquw03MEoB66hVBm4BnlCfmOqDVxHyT1DpA==}
+
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -4133,6 +4192,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.21.0':
     optional: true
 
+  '@rtsao/scc@1.1.0': {}
+
   '@rushstack/eslint-patch@1.10.4': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -4173,6 +4234,8 @@ snapshots:
   '@types/estree@1.0.5': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/json5@0.0.29': {}
 
   '@types/node@20.16.5':
     dependencies:
@@ -4518,6 +4581,15 @@ snapshots:
   array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
+      es-errors: 1.3.0
+      es-object-atoms: 1.0.0
+      es-shim-unscopables: 1.0.2
+
+  array.prototype.findlastindex@1.2.5:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
@@ -5109,13 +5181,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(eslint-plugin-i@2.29.1)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.1(eslint-plugin-import@2.30.0)(eslint@8.57.1):
     dependencies:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.2(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(eslint-plugin-i@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.2(eslint-import-resolver-typescript@3.6.1(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.30.0(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-core-module: 2.15.1
@@ -5126,13 +5198,22 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.2(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(eslint-plugin-i@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.11.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(eslint-plugin-i@2.29.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.1(eslint-plugin-import@2.30.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.8.2(eslint-import-resolver-typescript@3.6.1(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 8.57.1
+      eslint-import-resolver-typescript: 3.6.1(eslint-plugin-import@2.30.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5149,19 +5230,45 @@ snapshots:
       eslint: 8.57.1
       estraverse: 5.3.0
 
-  eslint-plugin-i@2.29.1(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+  eslint-plugin-import-x@4.3.1(eslint@8.57.1)(typescript@5.6.2):
     dependencies:
+      '@typescript-eslint/utils': 8.2.0(eslint@8.57.1)(typescript@5.6.2)
       debug: 4.3.6
       doctrine: 3.0.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.2(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(eslint-plugin-i@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       get-tsconfig: 4.7.6
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 9.0.5
       semver: 7.6.3
+      stable-hash: 0.0.4
+      tslib: 2.7.0
     transitivePeerDependencies:
-      - '@typescript-eslint/parser'
+      - supports-color
+      - typescript
+
+  eslint-plugin-import@2.30.0(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.11.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      hasown: 2.0.2
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
@@ -6024,6 +6131,10 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
+
   jsonfile@6.1.0:
     dependencies:
       universalify: 2.0.1
@@ -6224,6 +6335,12 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-object-atoms: 1.0.0
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
 
   object.values@1.2.0:
     dependencies:
@@ -6621,6 +6738,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stable-hash@0.0.4: {}
+
   stackback@0.0.2: {}
 
   std-env@3.7.0: {}
@@ -6689,6 +6808,8 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.0.1
+
+  strip-bom@3.0.0: {}
 
   strip-bom@4.0.0: {}
 
@@ -6776,6 +6897,13 @@ snapshots:
       typescript: 5.6.2
 
   ts-pattern@5.3.1: {}
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@1.14.1: {}
 

--- a/specs/eslint-configs/__snapshots__/presets.test.mts.snap
+++ b/specs/eslint-configs/__snapshots__/presets.test.mts.snap
@@ -23,7 +23,7 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
     "n",
     "@stylistic/js",
     "simple-import-sort",
-    "import",
+    "import-x",
   ],
   "reportUnusedDisableDirectives": true,
   "rules": {
@@ -150,10 +150,10 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
     "guard-for-in": [
       "error",
     ],
-    "import/export": [
+    "import-x/export": [
       "error",
     ],
-    "import/extensions": [
+    "import-x/extensions": [
       "warn",
       "ignorePackages",
       {
@@ -163,39 +163,34 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
         "tsx": "never",
       },
     ],
-    "import/first": [
+    "import-x/first": [
       "error",
     ],
-    "import/max-dependencies": [
+    "import-x/max-dependencies": [
       "off",
       {
         "max": 10,
       },
     ],
-    "import/named": [
+    "import-x/named": [
       "error",
     ],
-    "import/newline-after-import": [
+    "import-x/newline-after-import": [
       "error",
     ],
-    "import/no-absolute-path": [
+    "import-x/no-absolute-path": [
       "error",
     ],
-    "import/no-cycle": [
-      "error",
-      {
-        "allowUnsafeDynamicCyclicDependency": false,
-        "ignoreExternal": false,
-        "maxDepth": "∞",
-      },
-    ],
-    "import/no-duplicates": [
+    "import-x/no-cycle": [
       "error",
     ],
-    "import/no-dynamic-require": [
+    "import-x/no-duplicates": [
       "error",
     ],
-    "import/no-extraneous-dependencies": [
+    "import-x/no-dynamic-require": [
+      "error",
+    ],
+    "import-x/no-extraneous-dependencies": [
       "error",
       {
         "devDependencies": [
@@ -226,48 +221,47 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
         "optionalDependencies": false,
       },
     ],
-    "import/no-import-module-exports": [
+    "import-x/no-import-module-exports": [
       "error",
       {
         "exceptions": [],
       },
     ],
-    "import/no-mutable-exports": [
+    "import-x/no-mutable-exports": [
       "error",
     ],
-    "import/no-named-as-default": [
+    "import-x/no-named-as-default": [
       "error",
     ],
-    "import/no-named-as-default-member": [
+    "import-x/no-named-as-default-member": [
       "error",
     ],
-    "import/no-named-default": [
+    "import-x/no-named-default": [
       "error",
     ],
-    "import/no-relative-packages": [
+    "import-x/no-relative-packages": [
       "error",
     ],
-    "import/no-self-import": [
+    "import-x/no-self-import": [
       "error",
     ],
-    "import/no-unresolved": [
+    "import-x/no-unresolved": [
       "error",
       {
         "caseSensitive": true,
-        "caseSensitiveStrict": false,
         "commonjs": true,
       },
     ],
-    "import/no-useless-path-segments": [
+    "import-x/no-useless-path-segments": [
       "error",
       {
         "commonjs": true,
       },
     ],
-    "import/no-webpack-loader-syntax": [
+    "import-x/no-webpack-loader-syntax": [
       "error",
     ],
-    "import/order": [
+    "import-x/order": [
       "off",
     ],
     "lodash/prop-shorthand": [
@@ -966,17 +960,16 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
     ],
   },
   "settings": {
-    "import/core-modules": [],
-    "import/extensions": [
+    "import-x/extensions": [
       ".js",
       ".mjs",
       ".jsx",
     ],
-    "import/ignore": [
+    "import-x/ignore": [
       "node_modules",
       "\\.(coffee|scss|css|less|hbs|svg|json)$",
     ],
-    "import/resolver": {
+    "import-x/resolver": {
       "node": {
         "extensions": [
           ".mjs",
@@ -1014,7 +1007,7 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     "n",
     "@stylistic/js",
     "simple-import-sort",
-    "import",
+    "import-x",
     "@typescript-eslint",
     "@rightcapital",
   ],
@@ -1336,10 +1329,10 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     "guard-for-in": [
       "error",
     ],
-    "import/export": [
+    "import-x/export": [
       "error",
     ],
-    "import/extensions": [
+    "import-x/extensions": [
       "warn",
       "ignorePackages",
       {
@@ -1349,42 +1342,37 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
         "tsx": "never",
       },
     ],
-    "import/first": [
+    "import-x/first": [
       "error",
     ],
-    "import/max-dependencies": [
+    "import-x/max-dependencies": [
       "off",
       {
         "max": 10,
       },
     ],
-    "import/named": [
+    "import-x/named": [
       "error",
     ],
-    "import/newline-after-import": [
+    "import-x/newline-after-import": [
       "error",
     ],
-    "import/no-absolute-path": [
+    "import-x/no-absolute-path": [
       "error",
     ],
-    "import/no-cycle": [
+    "import-x/no-cycle": [
       "error",
-      {
-        "allowUnsafeDynamicCyclicDependency": false,
-        "ignoreExternal": false,
-        "maxDepth": "∞",
-      },
     ],
-    "import/no-duplicates": [
+    "import-x/no-duplicates": [
       "error",
       {
         "prefer-inline": true,
       },
     ],
-    "import/no-dynamic-require": [
+    "import-x/no-dynamic-require": [
       "error",
     ],
-    "import/no-extraneous-dependencies": [
+    "import-x/no-extraneous-dependencies": [
       "error",
       {
         "devDependencies": [
@@ -1415,48 +1403,47 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
         "optionalDependencies": false,
       },
     ],
-    "import/no-import-module-exports": [
+    "import-x/no-import-module-exports": [
       "error",
       {
         "exceptions": [],
       },
     ],
-    "import/no-mutable-exports": [
+    "import-x/no-mutable-exports": [
       "error",
     ],
-    "import/no-named-as-default": [
+    "import-x/no-named-as-default": [
       "error",
     ],
-    "import/no-named-as-default-member": [
+    "import-x/no-named-as-default-member": [
       "error",
     ],
-    "import/no-named-default": [
+    "import-x/no-named-default": [
       "error",
     ],
-    "import/no-relative-packages": [
+    "import-x/no-relative-packages": [
       "error",
     ],
-    "import/no-self-import": [
+    "import-x/no-self-import": [
       "error",
     ],
-    "import/no-unresolved": [
+    "import-x/no-unresolved": [
       "error",
       {
         "caseSensitive": true,
-        "caseSensitiveStrict": false,
         "commonjs": true,
       },
     ],
-    "import/no-useless-path-segments": [
+    "import-x/no-useless-path-segments": [
       "error",
       {
         "commonjs": true,
       },
     ],
-    "import/no-webpack-loader-syntax": [
+    "import-x/no-webpack-loader-syntax": [
       "error",
     ],
-    "import/order": [
+    "import-x/order": [
       "off",
     ],
     "lodash/prop-shorthand": [
@@ -2161,17 +2148,16 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     ],
   },
   "settings": {
-    "import/core-modules": [],
-    "import/extensions": [
+    "import-x/extensions": [
       ".js",
       ".mjs",
       ".jsx",
     ],
-    "import/ignore": [
+    "import-x/ignore": [
       "node_modules",
       "\\.(coffee|scss|css|less|hbs|svg|json)$",
     ],
-    "import/parsers": {
+    "import-x/parsers": {
       "@typescript-eslint/parser": [
         ".ts",
         ".cts",
@@ -2179,7 +2165,7 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
         ".tsx",
       ],
     },
-    "import/resolver": {
+    "import-x/resolver": {
       "node": {
         "extensions": [
           ".mjs",
@@ -2219,7 +2205,7 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     "n",
     "@stylistic/js",
     "simple-import-sort",
-    "import",
+    "import-x",
     "@typescript-eslint",
     "react-hooks",
     "react",
@@ -2687,10 +2673,10 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     "guard-for-in": [
       "error",
     ],
-    "import/export": [
+    "import-x/export": [
       "error",
     ],
-    "import/extensions": [
+    "import-x/extensions": [
       "warn",
       "ignorePackages",
       {
@@ -2700,42 +2686,37 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
         "tsx": "never",
       },
     ],
-    "import/first": [
+    "import-x/first": [
       "error",
     ],
-    "import/max-dependencies": [
+    "import-x/max-dependencies": [
       "off",
       {
         "max": 10,
       },
     ],
-    "import/named": [
+    "import-x/named": [
       "error",
     ],
-    "import/newline-after-import": [
+    "import-x/newline-after-import": [
       "error",
     ],
-    "import/no-absolute-path": [
+    "import-x/no-absolute-path": [
       "error",
     ],
-    "import/no-cycle": [
+    "import-x/no-cycle": [
       "error",
-      {
-        "allowUnsafeDynamicCyclicDependency": false,
-        "ignoreExternal": false,
-        "maxDepth": "∞",
-      },
     ],
-    "import/no-duplicates": [
+    "import-x/no-duplicates": [
       "error",
       {
         "prefer-inline": true,
       },
     ],
-    "import/no-dynamic-require": [
+    "import-x/no-dynamic-require": [
       "error",
     ],
-    "import/no-extraneous-dependencies": [
+    "import-x/no-extraneous-dependencies": [
       "error",
       {
         "devDependencies": [
@@ -2766,48 +2747,47 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
         "optionalDependencies": false,
       },
     ],
-    "import/no-import-module-exports": [
+    "import-x/no-import-module-exports": [
       "error",
       {
         "exceptions": [],
       },
     ],
-    "import/no-mutable-exports": [
+    "import-x/no-mutable-exports": [
       "error",
     ],
-    "import/no-named-as-default": [
+    "import-x/no-named-as-default": [
       "error",
     ],
-    "import/no-named-as-default-member": [
+    "import-x/no-named-as-default-member": [
       "error",
     ],
-    "import/no-named-default": [
+    "import-x/no-named-default": [
       "error",
     ],
-    "import/no-relative-packages": [
+    "import-x/no-relative-packages": [
       "error",
     ],
-    "import/no-self-import": [
+    "import-x/no-self-import": [
       "error",
     ],
-    "import/no-unresolved": [
+    "import-x/no-unresolved": [
       "error",
       {
         "caseSensitive": true,
-        "caseSensitiveStrict": false,
         "commonjs": true,
       },
     ],
-    "import/no-useless-path-segments": [
+    "import-x/no-useless-path-segments": [
       "error",
       {
         "commonjs": true,
       },
     ],
-    "import/no-webpack-loader-syntax": [
+    "import-x/no-webpack-loader-syntax": [
       "error",
     ],
-    "import/order": [
+    "import-x/order": [
       "off",
     ],
     "jsx-a11y/alt-text": [
@@ -3745,17 +3725,16 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     ],
   },
   "settings": {
-    "import/core-modules": [],
-    "import/extensions": [
+    "import-x/extensions": [
       ".js",
       ".mjs",
       ".jsx",
     ],
-    "import/ignore": [
+    "import-x/ignore": [
       "node_modules",
       "\\.(coffee|scss|css|less|hbs|svg|json)$",
     ],
-    "import/parsers": {
+    "import-x/parsers": {
       "@typescript-eslint/parser": [
         ".ts",
         ".cts",
@@ -3763,7 +3742,7 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
         ".tsx",
       ],
     },
-    "import/resolver": {
+    "import-x/resolver": {
       "node": {
         "extensions": [
           ".mjs",


### PR DESCRIPTION
Relates to https://github.com/RightCapitalHQ/frontend-style-guide/issues/128

This is the final blocking part for ESLint v9 support