### PR TITLE
feat: naming convention for React

### DIFF
--- a/change/@rightcapital-eslint-config-typescript-react-d9a48310-17af-4929-b6d4-db46aa57b38e.json
+++ b/change/@rightcapital-eslint-config-typescript-react-d9a48310-17af-4929-b6d4-db46aa57b38e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: naming convention for React",
+  "packageName": "@rightcapital/eslint-config-typescript-react",
+  "email": "45930107+PinkChampagne17@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-typescript-react/src/index.ts
+++ b/packages/eslint-config-typescript-react/src/index.ts
@@ -13,6 +13,12 @@ const config: Linter.Config = {
   plugins: ['@rightcapital', '@stylistic/jsx'],
   reportUnusedDisableDirectives: true,
   rules: {
+    '@eslint-react/naming-convention/component-name': ['error', 'PascalCase'],
+    '@eslint-react/naming-convention/filename': [
+      'error',
+      { rule: 'kebab-case' },
+    ],
+    '@eslint-react/naming-convention/use-state': 'error',
     '@eslint-react/no-useless-fragment': 'error',
     '@rightcapital/no-explicit-type-on-function-component-identifier': 'error',
     '@stylistic/jsx/jsx-self-closing-comp': 'error',

--- a/specs/eslint-configs/__snapshots__/presets.test.mts.snap
+++ b/specs/eslint-configs/__snapshots__/presets.test.mts.snap
@@ -2266,6 +2266,19 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     "@eslint-react/ensure-forward-ref-using-ref": [
       "warn",
     ],
+    "@eslint-react/naming-convention/component-name": [
+      "error",
+      "PascalCase",
+    ],
+    "@eslint-react/naming-convention/filename": [
+      "error",
+      {
+        "rule": "kebab-case",
+      },
+    ],
+    "@eslint-react/naming-convention/use-state": [
+      "error",
+    ],
     "@eslint-react/no-access-state-in-setstate": [
       "error",
     ],


### PR DESCRIPTION
Add the following rules to standardize React code naming convention.
- [@eslint-react/naming-convention/component-name](https://eslint-react.xyz/docs/rules/naming-convention-component-name)
- [@eslint-react/naming-convention/filename](https://eslint-react.xyz/docs/rules/naming-convention-filename)
- [@eslint-react/naming-convention/use-state](https://eslint-react.xyz/docs/rules/naming-convention-use-state)