### PR TITLE
feat: update `engines.node` for import attributes support

### DIFF
--- a/change/@rightcapital-eslint-config-8806539e-5da9-4e2d-af55-1f15f2f08fc2.json
+++ b/change/@rightcapital-eslint-config-8806539e-5da9-4e2d-af55-1f15f2f08fc2.json
@@ -1,0 +1,7 @@
+{
+  "comment": "feat: set engines.node for import attributes support",
+  "type": "patch",
+  "packageName": "@rightcapital/eslint-config",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -55,7 +55,7 @@
   },
   "packageManager": "pnpm@9.10.0",
   "engines": {
-    "node": ">=20"
+    "node": "^18.20.0 || ^20.10.0 || ^21.1.0 || >=22"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
We have used import attributes feature, setting proper `engines.node` field helps user select the right Node.js version

References:

- 18.20.0: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2024-03-26-version-18200-hydrogen-lts-richardlau
- 20.10.0: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-11-22-version-20100-iron-lts-targos
- 21.1.0: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V21.md#2023-10-24-version-2110-current-targos

relates to #204