### PR TITLE
feat: add `@typescript-eslint/consistent-type-definitions` rule

### DIFF
--- a/change/@rightcapital-eslint-config-71d267e9-1d09-4922-9d46-64cbcb8e5e35.json
+++ b/change/@rightcapital-eslint-config-71d267e9-1d09-4922-9d46-64cbcb8e5e35.json
@@ -1,0 +1,7 @@
+{
+  "comment": "feat(eslint-config): add `@typescript-eslint/consistent-type-definitions` rule",
+  "type": "major",
+  "packageName": "@rightcapital/eslint-config",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config/src/config/typescript.ts
+++ b/packages/eslint-config/src/config/typescript.ts
@@ -84,6 +84,9 @@ const config: TSESLint.FlatConfig.ConfigArray = [
         },
       ],
 
+      // https://typescript-eslint.io/rules/consistent-type-definitions/
+      '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+
       // https://typescript-eslint.io/rules/no-shadow/
       'no-shadow': 'off',
       '@typescript-eslint/no-shadow': 'error',

--- a/specs/eslint-configs/__snapshots__/presets.test.mts.snap
+++ b/specs/eslint-configs/__snapshots__/presets.test.mts.snap
@@ -1013,6 +1013,10 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     "@typescript-eslint/ban-ts-comment": [
       2,
     ],
+    "@typescript-eslint/consistent-type-definitions": [
+      2,
+      "interface",
+    ],
     "@typescript-eslint/consistent-type-exports": [
       2,
       {
@@ -3466,6 +3470,10 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     ],
     "@typescript-eslint/ban-ts-comment": [
       2,
+    ],
+    "@typescript-eslint/consistent-type-definitions": [
+      2,
+      "interface",
     ],
     "@typescript-eslint/consistent-type-exports": [
       2,


### PR DESCRIPTION
This will help maintain consistency in the codebase.