### PR TITLE
feat: add pnpm v10 support for `prettier-config`

### DIFF
--- a/change/@rightcapital-prettier-config-01eb988a-361a-4d35-be2e-a009e1d0e8a8.json
+++ b/change/@rightcapital-prettier-config-01eb988a-361a-4d35-be2e-a009e1d0e8a8.json
@@ -1,0 +1,7 @@
+{
+  "comment": "feat: add pnpm v10 support for `prettier-config`",
+  "type": "minor",
+  "packageName": "@rightcapital/prettier-config",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -7,7 +7,7 @@ const config: Options = {
   singleQuote: true,
   tabWidth: 2,
   trailingComma: 'all',
-  plugins: ['prettier-plugin-packagejson'],
+  plugins: [require.resolve('prettier-plugin-packagejson')],
 };
 
 export = config;


### PR DESCRIPTION
Use resolved path for prettier plugins since pnpm v10 no longer hoist prettier related packages by default

See: https://github.com/pnpm/pnpm/issues/8378