### PR TITLE
feat: add eslint-plugin-unused-imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.formatOnType": false,
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "cSpell.words": ["rightcapital"]
 }

--- a/change/@rightcapital-eslint-config-86a24130-a8cb-4cf1-b727-d861a96a5530.json
+++ b/change/@rightcapital-eslint-config-86a24130-a8cb-4cf1-b727-d861a96a5530.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add eslint-plugin-unused-imports",
+  "packageName": "@rightcapital/eslint-config",
+  "email": "45930107+PinkChampagne17@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "lint:eslint": "eslint --max-warnings=0 .",
     "lint:prettier": "prettier -c .",
     "prepare": "./scripts/prepare.sh",
-    "test": "pnpm run --recursive --aggregate-output --reporter-hide-prefix test",
-    "test:update-snapshots": "pnpm --aggregate-output --filter './specs/*' test -- -u"
+    "test": "pnpm run --recursive --aggregate-output --reporter-hide-prefix test --run",
+    "test:update-snapshots": "pnpm --aggregate-output --filter './specs/*' test --run -u"
   },
   "config": {
     "commitizen": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-react-hooks": "5.1.0",
     "eslint-plugin-simple-import-sort": "12.1.1",
     "eslint-plugin-unicorn": "56.0.1",
+    "eslint-plugin-unused-imports": "4.1.4",
     "globals": "15.14.0",
     "typescript-eslint": "8.18.2"
   },

--- a/packages/eslint-config/src/config/javascript.ts
+++ b/packages/eslint-config/src/config/javascript.ts
@@ -1,5 +1,6 @@
 import type { TSESLint } from '@typescript-eslint/utils';
 
+import { isInEditorEnv } from '../helpers/is-in-editor-env.js';
 import baseConfig from './base/index.js';
 
 /**
@@ -23,5 +24,14 @@ const config: TSESLint.FlatConfig.ConfigArray = [
     },
   },
 ];
+
+if (!isInEditorEnv()) {
+  config.push({
+    rules: {
+      'no-unused-vars': 'off',
+      'unused-imports/no-unused-imports': 'error',
+    },
+  });
+}
 
 export default config;

--- a/packages/eslint-config/src/config/typescript.ts
+++ b/packages/eslint-config/src/config/typescript.ts
@@ -1,6 +1,7 @@
 import type { TSESLint } from '@typescript-eslint/utils';
 import * as typescriptEslint from 'typescript-eslint';
 
+import { isInEditorEnv } from '../helpers/is-in-editor-env.js';
 import { pickPlugins } from '../utils.js';
 import baseConfig from './base/index.js';
 
@@ -152,5 +153,14 @@ const config: TSESLint.FlatConfig.ConfigArray = [
     },
   },
 ];
+
+if (!isInEditorEnv()) {
+  config.push({
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
+      'unused-imports/no-unused-imports': 'error',
+    },
+  });
+}
 
 export default config;

--- a/packages/eslint-config/src/helpers/is-in-editor-env.ts
+++ b/packages/eslint-config/src/helpers/is-in-editor-env.ts
@@ -1,0 +1,30 @@
+// Copied from https://github.com/antfu/eslint-config/blob/4f90101b6ea8af8ffbb49a77ed4fba75b8c69226/src/utils.ts#L135
+export const isInEditorEnv = (): boolean => {
+  const isInEditorEnvForTesting =
+    process.env.RC_ESLINT_CONFIG_TEST_FORCE_IS_IN_EDITOR;
+  if (typeof isInEditorEnvForTesting === 'string') {
+    return isInEditorEnvForTesting === String(1);
+  }
+  if (process.env.CI) {
+    return false;
+  }
+  if (isInGitHooksOrLintStaged()) {
+    return false;
+  }
+  return Boolean(
+    process.env.VSCODE_PID ||
+      process.env.VSCODE_CWD ||
+      process.env.JETBRAINS_IDE ||
+      process.env.VIM ||
+      process.env.NVIM,
+  );
+};
+
+// Copied form https://github.com/antfu/eslint-config/blob/4f90101b6ea8af8ffbb49a77ed4fba75b8c69226/src/utils.ts#L149
+export const isInGitHooksOrLintStaged = (): boolean => {
+  return Boolean(
+    process.env.GIT_PARAMS ||
+      process.env.VSCODE_GIT_COMMAND ||
+      process.env.npm_lifecycle_script?.startsWith('lint-staged'),
+  );
+};

--- a/packages/eslint-config/src/plugins/index.ts
+++ b/packages/eslint-config/src/plugins/index.ts
@@ -7,6 +7,7 @@ import eslintPluginLodash from 'eslint-plugin-lodash';
 import n from 'eslint-plugin-n';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
+import unusedImportsEslintPlugin from 'eslint-plugin-unused-imports';
 import * as typescriptEslint from 'typescript-eslint';
 
 import eslintPluginImportX from './eslint-plugin-import-x.js';
@@ -33,4 +34,5 @@ export const plugins = definePlugins({
   'jsx-a11y': eslintPluginA11y,
   lodash: eslintPluginLodash,
   unicorn: eslintPluginUnicorn,
+  'unused-imports': unusedImportsEslintPlugin,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       eslint-plugin-unicorn:
         specifier: 56.0.1
         version: 56.0.1(eslint@9.12.0(jiti@2.4.2))
+      eslint-plugin-unused-imports:
+        specifier: 4.1.4
+        version: 4.1.4(@typescript-eslint/eslint-plugin@8.18.2(@typescript-eslint/parser@8.18.2(eslint@9.12.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.12.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.12.0(jiti@2.4.2))
       globals:
         specifier: 15.14.0
         version: 15.14.0
@@ -236,10 +239,6 @@ importers:
         version: 2.51.0(typescript@5.7.2)
 
   specs/eslint-configs:
-    dependencies:
-      typescript:
-        specifier: 5.7.2
-        version: 5.7.2
     devDependencies:
       '@rightcapital/eslint-config':
         specifier: workspace:*
@@ -262,9 +261,15 @@ importers:
       execa:
         specifier: 9.5.2
         version: 9.5.2
+      jest-diff:
+        specifier: 29.7.0
+        version: 29.7.0
       prettier:
         specifier: 3.5.1
         version: 3.5.1
+      typescript:
+        specifier: 5.7.2
+        version: 5.7.2
       vitest:
         specifier: 2.1.9
         version: 2.1.9(@types/node@22.13.4)(@vitest/ui@2.1.9)
@@ -1876,6 +1881,15 @@ packages:
     engines: {node: '>=18.18'}
     peerDependencies:
       eslint: '>=8.56.0'
+
+  eslint-plugin-unused-imports@4.1.4:
+    resolution: {integrity: sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -5564,6 +5578,12 @@ snapshots:
       regjsparser: 0.10.0
       semver: 7.6.3
       strip-indent: 3.0.0
+
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.18.2(@typescript-eslint/parser@8.18.2(eslint@9.12.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.12.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.12.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.12.0(jiti@2.4.2)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.18.2(@typescript-eslint/parser@8.18.2(eslint@9.12.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.12.0(jiti@2.4.2))(typescript@5.7.3)
 
   eslint-scope@7.2.2:
     dependencies:

--- a/specs/eslint-configs/__snapshots__/presets.test.mts.snap
+++ b/specs/eslint-configs/__snapshots__/presets.test.mts.snap
@@ -5,6 +5,7 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
   "language": "<OMITTED>",
   "languageOptions": {
     "ecmaVersion": "latest",
+    "globals": {},
     "parser": "<OMITTED>",
     "parserOptions": {},
     "sourceType": "module",
@@ -748,7 +749,7 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       2,
     ],
     "no-unused-vars": [
-      2,
+      0,
       {
         "args": "after-used",
         "ignoreRestSiblings": true,
@@ -895,6 +896,9 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
     "unicorn/text-encoding-identifier-case": [
       2,
     ],
+    "unused-imports/no-unused-imports": [
+      2,
+    ],
     "use-isnan": [
       2,
     ],
@@ -935,11 +939,57 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
 }
 `;
 
+exports[`Resolved config matches snapshot > javascript.js 2`] = `
+"- Editor mode: false  - 5
++ Editor mode: true   + 1
+
+@@ -15,11 +15,10 @@
+      "lodash:eslint-plugin-lodash",
+      "unicorn:eslint-plugin-unicorn@56.0.1",
+      "import-x:eslint-plugin-import-x@4.6.1",
+      "simple-import-sort:eslint-plugin-simple-import-sort@12.1.1",
+      "@stylistic",
+-     "unused-imports:unused-imports",
+    ],
+    "rules": Object {
+      "@stylistic/lines-between-class-members": Array [
+        2,
+        "always",
+@@ -751,11 +750,11 @@
+      ],
+      "no-unused-private-class-members": Array [
+        2,
+      ],
+      "no-unused-vars": Array [
+-       0,
++       2,
+        Object {
+          "args": "after-used",
+          "ignoreRestSiblings": true,
+          "vars": "all",
+        },
+@@ -896,13 +895,10 @@
+      ],
+      "unicorn/prefer-node-protocol": Array [
+        2,
+      ],
+      "unicorn/text-encoding-identifier-case": Array [
+-       2,
+-     ],
+-     "unused-imports/no-unused-imports": Array [
+        2,
+      ],
+      "use-isnan": Array [
+        2,
+      ],"
+`;
+
 exports[`Resolved config matches snapshot > typescript.ts 1`] = `
 {
   "language": "<OMITTED>",
   "languageOptions": {
     "ecmaVersion": "latest",
+    "globals": {},
     "parser": "<OMITTED>",
     "parserOptions": {
       "projectService": true,
@@ -1146,7 +1196,7 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
       2,
     ],
     "@typescript-eslint/no-unused-vars": [
-      2,
+      0,
       {
         "argsIgnorePattern": "^_",
       },
@@ -2037,6 +2087,9 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     "unicorn/text-encoding-identifier-case": [
       2,
     ],
+    "unused-imports/no-unused-imports": [
+      2,
+    ],
     "use-isnan": [
       2,
     ],
@@ -2083,6 +2136,51 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     },
   },
 }
+`;
+
+exports[`Resolved config matches snapshot > typescript.ts 2`] = `
+"- Editor mode: false  - 5
++ Editor mode: true   + 1
+
+@@ -19,11 +19,10 @@
+      "import-x:eslint-plugin-import-x@4.6.1",
+      "simple-import-sort:eslint-plugin-simple-import-sort@12.1.1",
+      "@stylistic",
+      "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
+      "@rightcapital:@rightcapital/eslint-plugin@42.0.0",
+-     "unused-imports:unused-imports",
+    ],
+    "rules": Object {
+      "@rightcapital/no-explicit-type-on-function-component-identifier": Array [
+        2,
+      ],
+@@ -216,11 +215,11 @@
+      ],
+      "@typescript-eslint/no-unused-expressions": Array [
+        2,
+      ],
+      "@typescript-eslint/no-unused-vars": Array [
+-       0,
++       2,
+        Object {
+          "argsIgnorePattern": "^_",
+        },
+      ],
+      "@typescript-eslint/no-use-before-define": Array [
+@@ -1105,13 +1104,10 @@
+      ],
+      "unicorn/prefer-node-protocol": Array [
+        2,
+      ],
+      "unicorn/text-encoding-identifier-case": Array [
+-       2,
+-     ],
+-     "unused-imports/no-unused-imports": Array [
+        2,
+      ],
+      "use-isnan": Array [
+        2,
+      ],"
 `;
 
 exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
@@ -3613,7 +3711,7 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
       2,
     ],
     "@typescript-eslint/no-unused-vars": [
-      2,
+      0,
       {
         "argsIgnorePattern": "^_",
       },
@@ -4739,6 +4837,9 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     "unicorn/text-encoding-identifier-case": [
       2,
     ],
+    "unused-imports/no-unused-imports": [
+      2,
+    ],
     "use-isnan": [
       2,
     ],
@@ -4795,4 +4896,49 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     },
   },
 }
+`;
+
+exports[`Resolved config matches snapshot > typescript-react.tsx 2`] = `
+"- Editor mode: false  - 5
++ Editor mode: true   + 1
+
+@@ -1148,11 +1148,10 @@
+      "import-x:eslint-plugin-import-x@4.6.1",
+      "simple-import-sort:eslint-plugin-simple-import-sort@12.1.1",
+      "@stylistic",
+      "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
+      "@rightcapital:@rightcapital/eslint-plugin@42.0.0",
+-     "unused-imports:unused-imports",
+      "@eslint-react:eslint-plugin-react-x@1.22.1",
+      "@eslint-react/dom:eslint-plugin-react-dom@1.22.1",
+      "@eslint-react/web-api:eslint-plugin-react-web-api@1.22.1",
+      "@eslint-react/debug:eslint-plugin-react-debug@1.22.1",
+      "@eslint-react/hooks-extra:eslint-plugin-react-hooks-extra@1.22.1",
+@@ -1540,11 +1539,11 @@
+      ],
+      "@typescript-eslint/no-unused-expressions": Array [
+        2,
+      ],
+      "@typescript-eslint/no-unused-vars": Array [
+-       0,
++       2,
+        Object {
+          "argsIgnorePattern": "^_",
+        },
+      ],
+      "@typescript-eslint/no-use-before-define": Array [
+@@ -2664,13 +2663,10 @@
+      ],
+      "unicorn/prefer-node-protocol": Array [
+        2,
+      ],
+      "unicorn/text-encoding-identifier-case": Array [
+-       2,
+-     ],
+-     "unused-imports/no-unused-imports": Array [
+        2,
+      ],
+      "use-isnan": Array [
+        2,
+      ],"
 `;

--- a/specs/eslint-configs/package.json
+++ b/specs/eslint-configs/package.json
@@ -8,9 +8,6 @@
     "lint:prettier-eslint": "prettier -c .",
     "test": "vitest"
   },
-  "dependencies": {
-    "typescript": "5.7.2"
-  },
   "devDependencies": {
     "@rightcapital/eslint-config": "workspace:*",
     "@rightcapital/prettier-config": "workspace:*",
@@ -19,7 +16,9 @@
     "eslint": "9.12.0",
     "eslint-config-prettier": "10.0.1",
     "execa": "9.5.2",
+    "jest-diff": "29.7.0",
     "prettier": "3.5.1",
+    "typescript": "5.7.2",
     "vitest": "2.1.9"
   }
 }


### PR DESCRIPTION
Add `eslint-plugin-unused-imports` ESLint plugin and `unused-imports/no-unused-imports` rule to `@rightcapital/eslint-config`.

In the editor environment, this rule will be disabled. Otherwise, the rule will be enabled and replace the `no-unused-vars` rule.

Close https://github.com/RightCapitalHQ/frontend-style-guide/issues/20.