### PR TITLE
Remove deprecated no-return-await ESLint rule

### DIFF
--- a/change/@rightcapital-eslint-config-db6f0dca-922c-40ee-99de-fd5bd813fc56.json
+++ b/change/@rightcapital-eslint-config-db6f0dca-922c-40ee-99de-fd5bd813fc56.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "refactor: remove deprecated no-return-await ESLint rule",
+  "packageName": "@rightcapital/eslint-config",
+  "email": "38807139+liby@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config/src/config/base/best-practices.ts
+++ b/packages/eslint-config/src/config/base/best-practices.ts
@@ -247,10 +247,6 @@ const config: TSESLint.FlatConfig.ConfigArray = [
       // https://eslint.org/docs/rules/no-return-assign
       'no-return-assign': ['error', 'always'],
 
-      // disallow redundant `return await`
-      // https://eslint.org/docs/rules/no-return-await
-      'no-return-await': 'error',
-
       // disallow use of `javascript:` urls.
       // https://eslint.org/docs/rules/no-script-url
       'no-script-url': 'error',

--- a/specs/eslint-configs/__snapshots__/presets.test.mts.snap
+++ b/specs/eslint-configs/__snapshots__/presets.test.mts.snap
@@ -709,9 +709,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       2,
       "always",
     ],
-    "no-return-await": [
-      2,
-    ],
     "no-script-url": [
       2,
     ],
@@ -1050,7 +1047,7 @@ exports[`Resolved config matches snapshot > javascript.js 2`] = `
 "- Editor mode: false  - 3
 + Editor mode: true   + 0
 
-@@ -982,13 +982,10 @@
+@@ -979,13 +979,10 @@
         2,
       ],
       "unicorn/text-encoding-identifier-case": Array [
@@ -1985,9 +1982,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
       2,
       "always",
     ],
-    "no-return-await": [
-      2,
-    ],
     "no-script-url": [
       2,
     ],
@@ -2337,7 +2331,7 @@ exports[`Resolved config matches snapshot > typescript.ts 2`] = `
 "- Editor mode: false  - 3
 + Editor mode: true   + 0
 
-@@ -1195,13 +1195,10 @@
+@@ -1192,13 +1192,10 @@
         2,
       ],
       "unicorn/text-encoding-identifier-case": Array [
@@ -4888,9 +4882,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
       2,
       "always",
     ],
-    "no-return-await": [
-      2,
-    ],
     "no-script-url": [
       2,
     ],
@@ -5262,7 +5253,7 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 2`] = `
 "- Editor mode: false  - 3
 + Editor mode: true   + 0
 
-@@ -2817,13 +2817,10 @@
+@@ -2814,13 +2814,10 @@
         2,
       ],
       "unicorn/text-encoding-identifier-case": Array [

--- a/specs/eslint-configs/presets.test.mts
+++ b/specs/eslint-configs/presets.test.mts
@@ -169,7 +169,7 @@ describe('Presets does not contain style rules', () => {
 });
 
 // FIXME: migrate these deprecated rules with alternatives or remove them?
-const ignoredDeprecatedRules = ['no-buffer-constructor', 'no-return-await'];
+const ignoredDeprecatedRules = ['no-buffer-constructor'];
 const lintResults = await Promise.all(
   sampleFiles.map(async (file) => [
     basename(file),

--- a/specs/lint-eslint-config-rules/lint-eslint-config-rules.test.mts
+++ b/specs/lint-eslint-config-rules/lint-eslint-config-rules.test.mts
@@ -20,7 +20,6 @@ for (const dirent of specDirs) {
 
         // from extended configs
         'no-buffer-constructor',
-        'no-return-await',
       ]),
     );
     expect(result.usedUnknownRuleIds).toEqual(


### PR DESCRIPTION
[The `no-return-await rule` was deprecated in ESLint v8.46.0 and is no longer necessary because](https://eslint.org/docs/latest/rules/no-return-await#options:~:text=This%20rule%20was%20deprecated%20in%20ESLint%20v8.46.0.%20There%20is%20no%20replacement%20rule.):

- Modern JavaScript engines have optimized return await performance  

- return await provides better stack traces for debugging

- ECMA-262 specification changes eliminated the performance concerns

Changes:

- Remove `no-return-await` rule from *best-practices* config

- Update test expectations to reflect rule removal  
 
- Update snapshots for configuration tests