### PR TITLE
chore: set proper ESLint and @eslint/core version and upgrade them together

### DIFF
--- a/change/@rightcapital-eslint-config-85c7a4ec-3e11-421b-8c72-0a9c6d004884.json
+++ b/change/@rightcapital-eslint-config-85c7a4ec-3e11-421b-8c72-0a9c6d004884.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: set proper ESLint and @eslint/core version and upgrade them together",
+  "packageName": "@rightcapital/eslint-config",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/change/@rightcapital-eslint-plugin-e596a546-23fd-42ea-8b9f-0042d349ae71.json
+++ b/change/@rightcapital-eslint-plugin-e596a546-23fd-42ea-8b9f-0042d349ae71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: set proper ESLint and @eslint/core version and upgrade them together",
+  "packageName": "@rightcapital/eslint-plugin",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/change/@rightcapital-lint-eslint-config-rules-f6dc6993-7d67-4e89-ae20-41cf43cc7b42.json
+++ b/change/@rightcapital-lint-eslint-config-rules-f6dc6993-7d67-4e89-ae20-41cf43cc7b42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: set proper ESLint and @eslint/core version and upgrade them together",
+  "packageName": "@rightcapital/lint-eslint-config-rules",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "beachball": "2.55.1",
     "commitizen": "4.3.1",
     "concurrently": "9.2.1",
-    "eslint": "9.38.0",
+    "eslint": "catalog:",
     "eslint-plugin-eslint-plugin": "7.0.0",
     "execa": "9.6.0",
     "husky": "9.1.7",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -44,11 +44,12 @@
     "@rightcapital/tsconfig": "workspace:*",
     "@types/confusing-browser-globals": "1.0.3",
     "@types/eslint-plugin-jsx-a11y": "6.10.1",
-    "@types/semver": "7.7.1"
+    "@types/semver": "7.7.1",
+    "eslint": "catalog:"
   },
   "peerDependencies": {
-    "eslint": ">=9",
-    "typescript": "^5.0.0"
+    "eslint": "9.x",
+    "typescript": "5.x"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -36,13 +36,13 @@
     "@typescript-eslint/rule-tester": "8.46.2",
     "@vitest/coverage-v8": "4.0.5",
     "@vitest/ui": "4.0.5",
-    "eslint": "9.38.0",
+    "eslint": "catalog:",
     "eslint-doc-generator": "2.3.0",
     "typescript": "5.9.3",
     "vitest": "4.0.5"
   },
   "peerDependencies": {
-    "eslint": ">=8.0.0"
+    "eslint": "9.x"
   },
   "packageManager": "pnpm@10.12.1",
   "engines": {

--- a/packages/lint-eslint-config-rules/package.json
+++ b/packages/lint-eslint-config-rules/package.json
@@ -39,7 +39,7 @@
     "typescript": "5.9.3"
   },
   "peerDependencies": {
-    "eslint": "^9.0.0"
+    "eslint": "9.x"
   },
   "packageManager": "pnpm@10.12.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@eslint/core':
       specifier: 0.16.0
       version: 0.16.0
+    eslint:
+      specifier: 9.38.0
+      version: 9.38.0
 
 importers:
 
@@ -45,7 +48,7 @@ importers:
         specifier: 9.2.1
         version: 9.2.1
       eslint:
-        specifier: 9.38.0
+        specifier: 'catalog:'
         version: 9.38.0(jiti@2.4.2)
       eslint-plugin-eslint-plugin:
         specifier: 7.0.0
@@ -83,9 +86,6 @@ importers:
       confusing-browser-globals:
         specifier: 1.0.11
         version: 1.0.11
-      eslint:
-        specifier: '>=9'
-        version: 9.38.0(jiti@2.4.2)
       eslint-import-resolver-typescript:
         specifier: 4.4.4
         version: 4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.4.2))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.4.2)))(eslint@9.38.0(jiti@2.4.2))
@@ -117,7 +117,7 @@ importers:
         specifier: 16.2.0
         version: 16.2.0
       typescript:
-        specifier: ^5.0.0
+        specifier: 5.x
         version: 5.9.3
       typescript-eslint:
         specifier: 8.46.2
@@ -138,6 +138,9 @@ importers:
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
+      eslint:
+        specifier: 'catalog:'
+        version: 9.38.0(jiti@2.4.2)
 
   packages/eslint-plugin:
     dependencies:
@@ -170,7 +173,7 @@ importers:
         specifier: 4.0.5
         version: 4.0.5(vitest@4.0.5)
       eslint:
-        specifier: 9.38.0
+        specifier: 'catalog:'
         version: 9.38.0(jiti@2.4.2)
       eslint-doc-generator:
         specifier: 2.3.0
@@ -191,7 +194,7 @@ importers:
         specifier: 3.42.0
         version: 3.42.0
       eslint:
-        specifier: ^9.0.0
+        specifier: 9.x
         version: 9.38.0(jiti@2.4.2)
     devDependencies:
       '@rightcapital/tsconfig':
@@ -259,7 +262,7 @@ importers:
         specifier: 9.2.1
         version: 9.2.1
       eslint:
-        specifier: 9.38.0
+        specifier: 'catalog:'
         version: 9.38.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: 10.1.8
@@ -301,7 +304,7 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/lint-eslint-config-rules
       eslint:
-        specifier: 9.38.0
+        specifier: 'catalog:'
         version: 9.38.0(jiti@2.4.2)
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - 'scripts'
 catalog:
   '@eslint/core': 0.16.0
+  eslint: 9.38.0

--- a/specs/eslint-configs/package.json
+++ b/specs/eslint-configs/package.json
@@ -13,7 +13,7 @@
     "@rightcapital/prettier-config": "workspace:*",
     "@types/react": "19.2.2",
     "concurrently": "9.2.1",
-    "eslint": "9.38.0",
+    "eslint": "catalog:",
     "eslint-config-prettier": "10.1.8",
     "execa": "9.6.0",
     "jest-diff": "30.2.0",

--- a/specs/lint-eslint-config-rules/fixtures/eslint-9-flat/package.json
+++ b/specs/lint-eslint-config-rules/fixtures/eslint-9-flat/package.json
@@ -4,6 +4,6 @@
   "devDependencies": {
     "@rightcapital/eslint-config": "workspace:*",
     "@rightcapital/lint-eslint-config-rules": "workspace:*",
-    "eslint": "9.38.0"
+    "eslint": "catalog:"
   }
 }


### PR DESCRIPTION
Changes:

- Added `eslint` as dev dependency for `eslint-config` package, allowing Renovate to upgrade `eslint` and `@eslint/core` properly
- Used catalog protocol for `eslint` in devdependencies
- Updated related peer dependency versions