### PR TITLE
feat(eslint-plugin): add rule `require-named-wrapped-component`

### DIFF
--- a/.nx/version-plans/version-plan-1772270723109.md
+++ b/.nx/version-plans/version-plan-1772270723109.md
@@ -1,0 +1,5 @@
+---
+eslint: minor
+---
+
+add rule `require-named-wrapped-component`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,3 +111,4 @@ CI enforcement:
 - ESLint uses modern flat config format (`eslint.config.mjs`)
 - Conventional commits are enforced via commitlint
 - Releases happen via Release PR workflow (not automatic on main)
+- Use `pnpm exec` or `pnpm dlx` instead of `npx` for running binaries

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -25,7 +25,8 @@
     "update:eslint-docs": "pnpm run build && eslint-doc-generator && prettier --write src/rules/**/*.md"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "8.56.0"
+    "@typescript-eslint/utils": "8.56.0",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@eslint/core": "catalog:",

--- a/packages/eslint-plugin/src/helpers/ast/function/is-anonymous-function.ts
+++ b/packages/eslint-plugin/src/helpers/ast/function/is-anonymous-function.ts
@@ -1,0 +1,16 @@
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
+
+/**
+ * Checks if a function node is anonymous (arrow function or unnamed function expression).
+ */
+export function isAnonymousFunction(
+  node: TSESTree.Node,
+): node is TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression {
+  if (node.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+    return true;
+  }
+  if (node.type === AST_NODE_TYPES.FunctionExpression && node.id === null) {
+    return true;
+  }
+  return false;
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -7,6 +7,7 @@ import { recommendedReactConfig } from './configs/recommended-react';
 import { jsxNoUnusedExpressionsRule } from './rules/jsx-no-unused-expressions/jsx-no-unused-expressions';
 import { noExplicitTypeOnFunctionComponentIdentifierRule } from './rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier';
 import { noIgnoreReturnValueOfReactHooksRule } from './rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks';
+import { requireNamedWrappedComponentRule } from './rules/require-named-wrapped-component/require-named-wrapped-component';
 
 // eslint-doc-generator can't resolve default export
 export const meta: ESLint.Plugin['meta'] = {
@@ -24,5 +25,6 @@ export const rules = {
   'no-ignore-return-value-of-react-hooks': noIgnoreReturnValueOfReactHooksRule,
   'no-explicit-type-on-function-component-identifier':
     noExplicitTypeOnFunctionComponentIdentifierRule,
+  'require-named-wrapped-component': requireNamedWrappedComponentRule,
   // FIXME: we may fix this when ESLint core types get better
 } as unknown as Record<string, RuleDefinition>;

--- a/packages/eslint-plugin/src/rules/require-named-wrapped-component/DECISIONS.md
+++ b/packages/eslint-plugin/src/rules/require-named-wrapped-component/DECISIONS.md
@@ -1,0 +1,27 @@
+# Technical Decisions
+
+## Naming Conventions
+
+This rule follows React's official HOC terminology as defined in the [React documentation](https://legacy.reactjs.org/docs/higher-order-components.html).
+
+### Terminology Reference
+
+| Term                             | Definition                                                    | Example                          |
+| -------------------------------- | ------------------------------------------------------------- | -------------------------------- |
+| **HOC** (Higher-Order Component) | A function that takes a component and returns a new component | `observer`, `forwardRef`, `memo` |
+| **Wrapped component**            | The component passed into the HOC                             | `() => <div>...</div>`           |
+| **Enhanced component**           | The new component returned by the HOC                         | `observer(() => ...)`            |
+
+### Rule Name: `require-named-wrapped-component`
+
+The rule name uses "wrapped component" because that's the official React term for the component passed into an HOC.
+
+### Option: `hocNames`
+
+List of HOC function names to check. Named `hocNames` because these functions ARE HOCs according to React's definition: "a function that takes a component and returns a new component".
+
+### Option: `includeReactHocs`
+
+Controls whether React's built-in HOCs (`forwardRef`, `memo`) are also checked. Named `includeReactHocs` to clearly indicate these are React's HOCs, not third-party ones.
+
+By default, React's HOCs are excluded because they handle display names automatically.

--- a/packages/eslint-plugin/src/rules/require-named-wrapped-component/require-named-wrapped-component.md
+++ b/packages/eslint-plugin/src/rules/require-named-wrapped-component/require-named-wrapped-component.md
@@ -1,0 +1,158 @@
+# require-named-wrapped-component
+
+Require wrapped components passed to HOCs to be named functions.
+
+## Background
+
+React-related ESLint rules (such as `react-hooks/rules-of-hooks`) determine whether a function is a React component by checking the function name. When passing anonymous inline functions (wrapped components) to HOCs, these rules fail to recognize them as components, leading to:
+
+1. React-related ESLint rules not recognizing the function as a component
+2. React DevTools displaying `Anonymous` or `<Unknown>`, making debugging difficult
+
+For more information on HOC terminology, see [React's official HOC documentation](https://legacy.reactjs.org/docs/higher-order-components.html).
+
+## Rule Details
+
+This rule detects anonymous inline functions (including arrow functions and anonymous function expressions) passed to HOCs and requires them to be named functions.
+
+### Incorrect Examples
+
+```tsx
+// ❌ Anonymous arrow function
+const EnhancedButton = observer(() => {
+  return <button>Click</button>;
+});
+
+// ❌ Anonymous function expression
+const EnhancedButton = observer(function () {
+  return <button>Click</button>;
+});
+```
+
+### Correct Examples
+
+```tsx
+// ✅ Named function expression
+const EnhancedButton = observer(function EnhancedButton() {
+  return <button>Click</button>;
+});
+
+// ✅ Define named component first, then pass reference
+const EnhancedButtonBase = () => <button>Click</button>;
+const EnhancedButton = observer(EnhancedButtonBase);
+
+// ✅ forwardRef exception: anonymous functions allowed (unless includeReactHocs is true)
+const EnhancedButton = forwardRef((props, ref) => {
+  return (
+    <button ref={ref} {...props}>
+      Click
+    </button>
+  );
+});
+
+// ✅ React.forwardRef is also an exception
+const EnhancedButton = React.forwardRef((props, ref) => {
+  return (
+    <button ref={ref} {...props}>
+      Click
+    </button>
+  );
+});
+
+// ✅ memo exception: anonymous functions allowed (unless includeReactHocs is true)
+const ExpensiveComponent = memo(() => {
+  return <div>Expensive</div>;
+});
+
+// ✅ HOC wrapping forwardRef, anonymous allowed inside forwardRef
+const EnhancedButton = observer(
+  forwardRef((props, ref) => {
+    return (
+      <button ref={ref} {...props}>
+        Click
+      </button>
+    );
+  }),
+);
+```
+
+## Auto-fix
+
+This rule supports auto-fix (`--fix`). The fix names the inline function based on the variable name that the HOC's return value is assigned to.
+
+### Fix Examples
+
+```tsx
+// Before: Anonymous arrow function
+const EnhancedButton = observer(() => {
+  return <button>Click</button>;
+});
+
+// After: Converted to named function expression
+const EnhancedButton = observer(function EnhancedButton() {
+  return <button>Click</button>;
+});
+```
+
+```tsx
+// Before: Anonymous function expression
+const EnhancedButton = observer(function () {
+  return <button>Click</button>;
+});
+
+// After: Function name added
+const EnhancedButton = observer(function EnhancedButton() {
+  return <button>Click</button>;
+});
+```
+
+### Cases That Cannot Be Auto-fixed
+
+The following cases cannot be auto-fixed and require manual handling:
+
+```tsx
+// ❌ Cannot determine variable name (e.g., direct export)
+export default observer(() => <button>Click</button>);
+
+// ❌ Cannot determine variable name (e.g., as object property)
+const components = {
+  Button: observer(() => <button>Click</button>),
+};
+
+// ❌ Cannot determine variable name (e.g., as array element)
+const list = [observer(() => <button>Click</button>)];
+```
+
+## Configuration Options
+
+```typescript
+interface Options {
+  /**
+   * List of HOC function names to check.
+   * Only wrapped components passed to these HOCs will be checked.
+   */
+  hocNames: string[];
+
+  /**
+   * Whether to also check React's built-in HOCs (forwardRef, memo).
+   * By default, these are exceptions since they handle display names automatically.
+   * @default false
+   */
+  includeReactHocs?: boolean;
+}
+```
+
+### Default Configuration
+
+```json
+{
+  "rules": {
+    "@rightcapital/require-named-wrapped-component": [
+      "error",
+      { "hocNames": ["observer"] }
+    ]
+  }
+}
+```
+
+By default, React's built-in HOCs (`forwardRef`, `React.forwardRef`, `memo`, `React.memo`) are exceptions and do not require named wrapped components. Set `includeReactHocs: true` to also require named components for these HOCs.

--- a/packages/eslint-plugin/src/rules/require-named-wrapped-component/require-named-wrapped-component.test.ts
+++ b/packages/eslint-plugin/src/rules/require-named-wrapped-component/require-named-wrapped-component.test.ts
@@ -1,0 +1,908 @@
+import { basename } from 'node:path';
+
+import parser from '@typescript-eslint/parser';
+
+import { VitestRuleTester } from '../../helpers/test/vitest-rule-tester';
+import { requireNamedWrappedComponentRule } from './require-named-wrapped-component';
+
+type RuleOptions = [{ hocNames: string[] }];
+
+const ruleTester = new VitestRuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+const ruleName = basename(__dirname);
+
+const defaultOptions: RuleOptions = [{ hocNames: ['observer'] }];
+
+const optionsWithBuiltinHocs: [
+  { hocNames: string[]; includeReactHocs: boolean },
+] = [{ hocNames: ['observer'], includeReactHocs: true }];
+
+ruleTester.run(`${ruleName} - valid cases`, requireNamedWrappedComponentRule, {
+  valid: [
+    // Named function expression
+    {
+      code: `const EnhancedButton = observer(function EnhancedButton() {
+        return <button>Click</button>;
+      });`,
+      options: defaultOptions,
+    },
+    // Reference to named component
+    {
+      code: `const EnhancedButtonBase = () => <button>Click</button>;
+const EnhancedButton = observer(EnhancedButtonBase);`,
+      options: defaultOptions,
+    },
+    // forwardRef exception - anonymous allowed
+    {
+      code: `const EnhancedButton = forwardRef((props, ref) => {
+        return <button ref={ref} {...props}>Click</button>;
+      });`,
+      options: defaultOptions,
+    },
+    // React.forwardRef exception
+    {
+      code: `const EnhancedButton = React.forwardRef((props, ref) => {
+        return <button ref={ref} {...props}>Click</button>;
+      });`,
+      options: defaultOptions,
+    },
+    // memo exception - anonymous allowed
+    {
+      code: `const ExpensiveComponent = memo(() => {
+        return <div>Expensive</div>;
+      });`,
+      options: defaultOptions,
+    },
+    // React.memo exception
+    {
+      code: `const ExpensiveComponent = React.memo(() => {
+        return <div>Expensive</div>;
+      });`,
+      options: defaultOptions,
+    },
+    // HOC wrapping forwardRef - anonymous allowed inside forwardRef
+    {
+      code: `const EnhancedButton = observer(
+        forwardRef((props, ref) => {
+          return <button ref={ref} {...props}>Click</button>;
+        })
+      );`,
+      options: defaultOptions,
+    },
+    // HOC wrapping React.forwardRef
+    {
+      code: `const EnhancedButton = observer(
+        React.forwardRef((props, ref) => {
+          return <button ref={ref} {...props}>Click</button>;
+        })
+      );`,
+      options: defaultOptions,
+    },
+    // HOC wrapping memo
+    {
+      code: `const EnhancedButton = observer(
+        memo(() => <button>Click</button>)
+      );`,
+      options: defaultOptions,
+    },
+    // HOC wrapping React.memo
+    {
+      code: `const EnhancedButton = observer(
+        React.memo(() => <button>Click</button>)
+      );`,
+      options: defaultOptions,
+    },
+    // Not a configured HOC factory
+    {
+      code: `const Something = someOtherHoc(() => <div>Hi</div>);`,
+      options: defaultOptions,
+    },
+    // Empty options - no HOCs configured
+    {
+      code: `const Something = observer(() => <div>Hi</div>);`,
+      options: [{ hocNames: [] }] satisfies RuleOptions,
+    },
+    // Named function expression with parameters
+    {
+      code: `const EnhancedButton = observer(function EnhancedButton(props) {
+        return <button {...props}>Click</button>;
+      });`,
+      options: defaultOptions,
+    },
+  ],
+
+  invalid: [],
+});
+
+ruleTester.run(
+  `${ruleName} - invalid cases with auto-fix`,
+  requireNamedWrappedComponentRule,
+  {
+    valid: [],
+
+    invalid: [
+      // Anonymous arrow function with block body
+      {
+        code: `const EnhancedButton = observer(() => {
+  return <button>Click</button>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(function EnhancedButton() {
+  return <button>Click</button>;
+});`,
+      },
+      // Anonymous arrow function with expression body
+      {
+        code: `const EnhancedButton = observer(() => <button>Click</button>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(function EnhancedButton() { return <button>Click</button>; });`,
+      },
+      // Anonymous function expression
+      {
+        code: `const EnhancedButton = observer(function () {
+  return <button>Click</button>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(function EnhancedButton() {
+  return <button>Click</button>;
+});`,
+      },
+      // Arrow function with parameters
+      {
+        code: `const EnhancedButton = observer((props) => {
+  return <button {...props}>Click</button>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(function EnhancedButton(props) {
+  return <button {...props}>Click</button>;
+});`,
+      },
+      // Async arrow function
+      {
+        code: `const EnhancedButton = observer(async () => {
+  await fetch('/api');
+  return <button>Click</button>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(async function EnhancedButton() {
+  await fetch('/api');
+  return <button>Click</button>;
+});`,
+      },
+      // Multiple HOC factories configured
+      {
+        code: `const EnhancedButton = connect(() => <button>Click</button>);`,
+        options: [{ hocNames: ['observer', 'connect'] }] satisfies RuleOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'connect' },
+          },
+        ],
+        output: `const EnhancedButton = connect(function EnhancedButton() { return <button>Click</button>; });`,
+      },
+      // Arrow function with multiple parameters
+      {
+        code: `const EnhancedButton = observer((props, context) => {
+  return <button {...props}>Click</button>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(function EnhancedButton(props, context) {
+  return <button {...props}>Click</button>;
+});`,
+      },
+      // Arrow function with destructured parameters
+      {
+        code: `const EnhancedButton = observer(({ onClick, children }) => {
+  return <button onClick={onClick}>{children}</button>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(function EnhancedButton({ onClick, children }) {
+  return <button onClick={onClick}>{children}</button>;
+});`,
+      },
+      // Single parameter without parentheses - expression body
+      {
+        code: `const EnhancedButton = observer(props => <button {...props}>Click</button>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(function EnhancedButton(props) { return <button {...props}>Click</button>; });`,
+      },
+      // Single parameter without parentheses - block body
+      {
+        code: `const EnhancedButton = observer(props => {
+  return <button {...props}>Click</button>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const EnhancedButton = observer(function EnhancedButton(props) {
+  return <button {...props}>Click</button>;
+});`,
+      },
+    ],
+  },
+);
+
+ruleTester.run(
+  `${ruleName} - unfixable cases`,
+  requireNamedWrappedComponentRule,
+  {
+    valid: [],
+
+    invalid: [
+      // Cannot auto-fix: export default
+      {
+        code: `export default observer(() => <button>Click</button>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        // No output - unfixable (output should be same as input when no fix)
+        output: null,
+      },
+      // Cannot auto-fix: object property
+      {
+        code: `const components = {
+  Button: observer(() => <button>Click</button>),
+};`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: null,
+      },
+      // Cannot auto-fix: array element
+      {
+        code: `const list = [observer(() => <button>Click</button>)];`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: null,
+      },
+      // Cannot auto-fix: function argument
+      {
+        code: `someFunction(observer(() => <button>Click</button>));`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: null,
+      },
+    ],
+  },
+);
+
+ruleTester.run(
+  `${ruleName} - custom HOC with builtin name`,
+  requireNamedWrappedComponentRule,
+  {
+    valid: [],
+
+    invalid: [
+      // Custom HOC named "memo" should still be checked when explicitly configured
+      {
+        code: `const Foo = myHocs.memo(() => <div/>);`,
+        options: [{ hocNames: ['myHocs.memo'] }] satisfies RuleOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'myHocs.memo' },
+          },
+        ],
+        output: `const Foo = myHocs.memo(function Foo() { return <div/>; });`,
+      },
+      // Custom HOC named "forwardRef" should still be checked when explicitly configured
+      {
+        code: `const Foo = customLib.forwardRef(() => <div/>);`,
+        options: [{ hocNames: ['customLib.forwardRef'] }] satisfies RuleOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'customLib.forwardRef' },
+          },
+        ],
+        output: `const Foo = customLib.forwardRef(function Foo() { return <div/>; });`,
+      },
+    ],
+  },
+);
+
+ruleTester.run(
+  `${ruleName} - includeReactHocs option`,
+  requireNamedWrappedComponentRule,
+  {
+    valid: [
+      // Named function inside forwardRef with includeReactHocs: true
+      {
+        code: `const EnhancedButton = forwardRef(function EnhancedButton(props, ref) {
+        return <button ref={ref} {...props}>Click</button>;
+      });`,
+        options: optionsWithBuiltinHocs,
+      },
+      // Named function inside memo with includeReactHocs: true
+      {
+        code: `const ExpensiveComponent = memo(function ExpensiveComponent() {
+        return <div>Expensive</div>;
+      });`,
+        options: optionsWithBuiltinHocs,
+      },
+      // Named function inside React.forwardRef with includeReactHocs: true
+      {
+        code: `const EnhancedButton = React.forwardRef(function EnhancedButton(props, ref) {
+        return <button ref={ref} {...props}>Click</button>;
+      });`,
+        options: optionsWithBuiltinHocs,
+      },
+      // Named function inside React.memo with includeReactHocs: true
+      {
+        code: `const ExpensiveComponent = React.memo(function ExpensiveComponent() {
+        return <div>Expensive</div>;
+      });`,
+        options: optionsWithBuiltinHocs,
+      },
+      // Reference to named component inside forwardRef
+      {
+        code: `const EnhancedButtonBase = (props, ref) => <button ref={ref}>Click</button>;
+const EnhancedButton = forwardRef(EnhancedButtonBase);`,
+        options: optionsWithBuiltinHocs,
+      },
+    ],
+
+    invalid: [
+      // Anonymous function inside forwardRef with includeReactHocs: true
+      {
+        code: `const EnhancedButton = forwardRef((props, ref) => {
+  return <button ref={ref} {...props}>Click</button>;
+});`,
+        options: optionsWithBuiltinHocs,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'forwardRef' },
+          },
+        ],
+        output: `const EnhancedButton = forwardRef(function EnhancedButton(props, ref) {
+  return <button ref={ref} {...props}>Click</button>;
+});`,
+      },
+      // Anonymous function inside memo with includeReactHocs: true
+      {
+        code: `const ExpensiveComponent = memo(() => {
+  return <div>Expensive</div>;
+});`,
+        options: optionsWithBuiltinHocs,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'memo' },
+          },
+        ],
+        output: `const ExpensiveComponent = memo(function ExpensiveComponent() {
+  return <div>Expensive</div>;
+});`,
+      },
+      // Anonymous function inside React.forwardRef with includeReactHocs: true
+      {
+        code: `const EnhancedButton = React.forwardRef((props, ref) => {
+  return <button ref={ref} {...props}>Click</button>;
+});`,
+        options: optionsWithBuiltinHocs,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'React.forwardRef' },
+          },
+        ],
+        output: `const EnhancedButton = React.forwardRef(function EnhancedButton(props, ref) {
+  return <button ref={ref} {...props}>Click</button>;
+});`,
+      },
+      // Anonymous function inside React.memo with includeReactHocs: true
+      {
+        code: `const ExpensiveComponent = React.memo(() => {
+  return <div>Expensive</div>;
+});`,
+        options: optionsWithBuiltinHocs,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'React.memo' },
+          },
+        ],
+        output: `const ExpensiveComponent = React.memo(function ExpensiveComponent() {
+  return <div>Expensive</div>;
+});`,
+      },
+      // observer wrapping forwardRef with anonymous - should error on forwardRef
+      {
+        code: `const EnhancedButton = observer(
+  forwardRef((props, ref) => <button ref={ref}>Click</button>)
+);`,
+        options: optionsWithBuiltinHocs,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'forwardRef' },
+          },
+        ],
+        output: null,
+      },
+    ],
+  },
+);
+
+ruleTester.run(
+  `${ruleName} - object name matching`,
+  requireNamedWrappedComponentRule,
+  {
+    valid: [
+      // Named function in VariantContext.createComponent
+      {
+        code: `const Foo = VariantContext.createComponent(function Foo() {
+        return <div/>;
+      });`,
+        options: [{ hocNames: ['VariantContext'] }] satisfies RuleOptions,
+      },
+      // Reference to named component
+      {
+        code: `const FooBase = () => <div/>;
+const Foo = VariantContext.createComponent(FooBase);`,
+        options: [{ hocNames: ['VariantContext'] }] satisfies RuleOptions,
+      },
+      // Different method on same object
+      {
+        code: `const Foo = VariantContext.withVariant(function Foo() {
+        return <div/>;
+      });`,
+        options: [{ hocNames: ['VariantContext'] }] satisfies RuleOptions,
+      },
+      // Not a configured object
+      {
+        code: `const Foo = OtherContext.createComponent(() => <div/>);`,
+        options: [{ hocNames: ['VariantContext'] }] satisfies RuleOptions,
+      },
+    ],
+
+    invalid: [
+      // Anonymous arrow function in VariantContext.createComponent
+      {
+        code: `const Foo = VariantContext.createComponent(() => <div/>);`,
+        options: [{ hocNames: ['VariantContext'] }] satisfies RuleOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'VariantContext.createComponent' },
+          },
+        ],
+        output: `const Foo = VariantContext.createComponent(function Foo() { return <div/>; });`,
+      },
+      // Anonymous function expression
+      {
+        code: `const Foo = VariantContext.createComponent(function () {
+  return <div/>;
+});`,
+        options: [{ hocNames: ['VariantContext'] }] satisfies RuleOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'VariantContext.createComponent' },
+          },
+        ],
+        output: `const Foo = VariantContext.createComponent(function Foo() {
+  return <div/>;
+});`,
+      },
+      // Different method on the same object
+      {
+        code: `const Bar = VariantContext.withVariant(() => <span/>);`,
+        options: [{ hocNames: ['VariantContext'] }] satisfies RuleOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'VariantContext.withVariant' },
+          },
+        ],
+        output: `const Bar = VariantContext.withVariant(function Bar() { return <span/>; });`,
+      },
+    ],
+  },
+);
+
+ruleTester.run(
+  `${ruleName} - property name matching`,
+  requireNamedWrappedComponentRule,
+  {
+    valid: [
+      // Named function with property name config
+      {
+        code: `const Foo = AnyContext.createComponent(function Foo() {
+        return <div/>;
+      });`,
+        options: [{ hocNames: ['createComponent'] }] satisfies RuleOptions,
+      },
+      // Reference to named component
+      {
+        code: `const FooBase = () => <div/>;
+const Foo = SomeContext.createComponent(FooBase);`,
+        options: [{ hocNames: ['createComponent'] }] satisfies RuleOptions,
+      },
+      // Not a configured property name
+      {
+        code: `const Foo = SomeContext.otherMethod(() => <div/>);`,
+        options: [{ hocNames: ['createComponent'] }] satisfies RuleOptions,
+      },
+    ],
+
+    invalid: [
+      // Anonymous arrow function with property name config
+      {
+        code: `const Foo = AnyContext.createComponent(() => <div/>);`,
+        options: [{ hocNames: ['createComponent'] }] satisfies RuleOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'AnyContext.createComponent' },
+          },
+        ],
+        output: `const Foo = AnyContext.createComponent(function Foo() { return <div/>; });`,
+      },
+      // Different object, same property name
+      {
+        code: `const Bar = OtherContext.createComponent(() => <span/>);`,
+        options: [{ hocNames: ['createComponent'] }] satisfies RuleOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'OtherContext.createComponent' },
+          },
+        ],
+        output: `const Bar = OtherContext.createComponent(function Bar() { return <span/>; });`,
+      },
+    ],
+  },
+);
+
+ruleTester.run(
+  `${ruleName} - TypeScript type preservation`,
+  requireNamedWrappedComponentRule,
+  {
+    valid: [],
+
+    invalid: [
+      // Should preserve type parameters
+      {
+        code: `const Foo = observer(<T,>(props: T) => <div/>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo<T,>(props: T) { return <div/>; });`,
+      },
+      // Should preserve return type annotation
+      {
+        code: `const Foo = observer((props): React.ReactNode => <div/>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo(props): React.ReactNode { return <div/>; });`,
+      },
+      // Should preserve both type parameters and return type
+      {
+        code: `const Foo = observer(<T extends object,>(props: T): React.ReactNode => <div/>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo<T extends object,>(props: T): React.ReactNode { return <div/>; });`,
+      },
+      // Should preserve complex type parameters with constraints
+      {
+        code: `const Foo = observer(<T extends { id: string }, K extends keyof T>(props: T, key: K): JSX.Element => {
+  return <div>{props[key]}</div>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo<T extends { id: string }, K extends keyof T>(props: T, key: K): JSX.Element {
+  return <div>{props[key]}</div>;
+});`,
+      },
+      // Should handle generic anonymous function expression
+      {
+        code: `const Foo = observer(function <T>(x: T) { return <div>{x}</div>; });`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo<T>(x: T) { return <div>{x}</div>; });`,
+      },
+      // Should handle generic anonymous function expression with constraints
+      {
+        code: `const Foo = observer(function <T extends object>(props: T) {
+  return <div/>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo<T extends object>(props: T) {
+  return <div/>;
+});`,
+      },
+    ],
+  },
+);
+
+ruleTester.run(
+  `${ruleName} - comment preservation`,
+  requireNamedWrappedComponentRule,
+  {
+    valid: [],
+
+    invalid: [
+      // Comments inside function body should be preserved
+      {
+        code: `const Foo = observer(() => {
+  // This is a comment inside the body
+  return <div/>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo() {
+  // This is a comment inside the body
+  return <div/>;
+});`,
+      },
+      // Comments inside parameter (after destructuring) should be preserved
+      {
+        code: `const Foo = observer(({ onClick /* click handler */ }) => {
+  return <button onClick={onClick}/>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo({ onClick /* click handler */ }) {
+  return <button onClick={onClick}/>;
+});`,
+      },
+      // Multi-line comments in body should be preserved
+      {
+        code: `const Foo = observer(() => {
+  /**
+   * JSDoc style comment
+   */
+  return <div/>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo() {
+  /**
+   * JSDoc style comment
+   */
+  return <div/>;
+});`,
+      },
+      // Comments inside anonymous function expression body should be preserved
+      {
+        code: `const Foo = observer(function () {
+  // comment in function expression
+  return <div/>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo() {
+  // comment in function expression
+  return <div/>;
+});`,
+      },
+      // Comment between parameters should be preserved
+      {
+        code: `const Foo = observer((props, /* separator */ context) => {
+  return <div/>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo(props, /* separator */ context) {
+  return <div/>;
+});`,
+      },
+      // Multiple comments between multiple parameters
+      {
+        code: `const Foo = observer((a, /* first */ b, /* second */ c) => <div/>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo(a, /* first */ b, /* second */ c) { return <div/>; });`,
+      },
+      // Multi-line parameters with comments
+      {
+        code: `const Foo = observer((
+  props, // props comment
+  ref // ref comment
+) => {
+  return <div/>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo(
+  props, // props comment
+  ref // ref comment
+) {
+  return <div/>;
+});`,
+      },
+      // Nested parentheses in parameter type (function type)
+      {
+        code: `const Foo = observer((props: { onClick: (e: Event) => void }) => <div/>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo(props: { onClick: (e: Event) => void }) { return <div/>; });`,
+      },
+      // Multiple nested parentheses in parameters
+      {
+        code: `const Foo = observer((fn: (a: (b: number) => string) => void, cb: () => void) => <div/>);`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo(fn: (a: (b: number) => string) => void, cb: () => void) { return <div/>; });`,
+      },
+      // Nested parentheses with comments
+      {
+        code: `const Foo = observer((
+  props: { onClick: (e: Event) => void }, // click handler type
+  ref
+) => {
+  return <div/>;
+});`,
+        options: defaultOptions,
+        errors: [
+          {
+            messageId: 'requireNamedComponent',
+            data: { hocName: 'observer' },
+          },
+        ],
+        output: `const Foo = observer(function Foo(
+  props: { onClick: (e: Event) => void }, // click handler type
+  ref
+) {
+  return <div/>;
+});`,
+      },
+    ],
+  },
+);

--- a/packages/eslint-plugin/src/rules/require-named-wrapped-component/require-named-wrapped-component.ts
+++ b/packages/eslint-plugin/src/rules/require-named-wrapped-component/require-named-wrapped-component.ts
@@ -1,0 +1,316 @@
+import { basename } from 'node:path';
+
+import {
+  AST_NODE_TYPES,
+  type TSESLint,
+  type TSESTree,
+} from '@typescript-eslint/utils';
+import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema';
+import { z } from 'zod';
+
+import { isAnonymousFunction } from '../../helpers/ast/function/is-anonymous-function';
+import { createRule } from '../../helpers/create-rule';
+
+const optionSchema = z.object({
+  hocNames: z.array(z.string()),
+  includeReactHocs: z.boolean().optional(),
+});
+
+type Options = [z.infer<typeof optionSchema>];
+type MessageIds = 'requireNamedComponent';
+
+/**
+ * Gets the callee name from a CallExpression.
+ * Handles both simple identifiers (observer) and member expressions (React.forwardRef).
+ */
+function getCalleeName(callee: TSESTree.Expression): string | null {
+  if (callee.type === AST_NODE_TYPES.Identifier) {
+    return callee.name;
+  }
+  if (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.object.type === AST_NODE_TYPES.Identifier &&
+    callee.property.type === AST_NODE_TYPES.Identifier
+  ) {
+    return `${callee.object.name}.${callee.property.name}`;
+  }
+  return null;
+}
+
+/**
+ * Gets the object name from a member expression callee.
+ * For example, for `TextButtonVariantContext.createComponent()`, returns 'TextButtonVariantContext'.
+ */
+function getCalleeObjectName(callee: TSESTree.Expression): string | null {
+  if (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.object.type === AST_NODE_TYPES.Identifier
+  ) {
+    return callee.object.name;
+  }
+  return null;
+}
+
+/**
+ * Gets the property name from a member expression callee.
+ * For example, for `VariantContext.createComponent()`, returns 'createComponent'.
+ */
+function getCalleePropertyName(callee: TSESTree.Expression): string | null {
+  if (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.property.type === AST_NODE_TYPES.Identifier
+  ) {
+    return callee.property.name;
+  }
+  return null;
+}
+
+/**
+ * React's built-in HOCs that handle display names automatically.
+ * By default, these are exceptions (anonymous wrapped components allowed).
+ * @see https://legacy.reactjs.org/docs/higher-order-components.html
+ */
+export const REACT_HOCS = new Set(['forwardRef', 'memo']);
+
+/**
+ * Checks if the callee is a React HOC (forwardRef, memo).
+ */
+function isExceptionCallee(callee: TSESTree.Expression): boolean {
+  if (callee.type === AST_NODE_TYPES.Identifier) {
+    return REACT_HOCS.has(callee.name);
+  }
+  if (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.property.type === AST_NODE_TYPES.Identifier
+  ) {
+    return REACT_HOCS.has(callee.property.name);
+  }
+  return false;
+}
+
+/**
+ * Gets the variable name from the parent VariableDeclarator if available.
+ * Used to determine the name for the auto-fix.
+ */
+function getVariableName(node: TSESTree.CallExpression): string | null {
+  const { parent } = node;
+  if (
+    parent?.type === AST_NODE_TYPES.VariableDeclarator &&
+    parent.id.type === AST_NODE_TYPES.Identifier
+  ) {
+    return parent.id.name;
+  }
+  return null;
+}
+
+/**
+ * Generates the fix for an anonymous function.
+ * Converts arrow functions and anonymous function expressions to named function expressions.
+ */
+function generateFix(
+  fixer: TSESLint.RuleFixer,
+  sourceCode: Readonly<TSESLint.SourceCode>,
+  funcNode: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+  variableName: string,
+): TSESLint.RuleFix | null {
+  if (funcNode.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+    // Arrow function: (props) => { ... } or props => expr
+    // Use AST param ranges to avoid confusing body parentheses as parameter parentheses.
+    let paramsText = '';
+    if (funcNode.params.length > 0) {
+      const firstParam = funcNode.params[0];
+      const lastParam = funcNode.params[funcNode.params.length - 1];
+      const tokenBeforeFirstParam = sourceCode.getTokenBefore(firstParam);
+      const tokenAfterLastParam = sourceCode.getTokenAfter(lastParam);
+
+      if (
+        tokenBeforeFirstParam?.value === '(' &&
+        tokenAfterLastParam?.value === ')'
+      ) {
+        // Keep original formatting/comments between parentheses.
+        paramsText = sourceCode.text.slice(
+          tokenBeforeFirstParam.range[1],
+          tokenAfterLastParam.range[0],
+        );
+      } else {
+        // Single parameter without parentheses (e.g., props => <div/>)
+        paramsText = funcNode.params
+          .map((param) => sourceCode.getText(param))
+          .join(', ');
+      }
+    }
+    const bodyText = sourceCode.getText(funcNode.body);
+
+    // Preserve type parameters (e.g., <T extends object>)
+    const typeParamsText = funcNode.typeParameters
+      ? sourceCode.getText(funcNode.typeParameters)
+      : '';
+
+    // Preserve return type annotation (e.g., : JSX.Element)
+    const returnTypeText = funcNode.returnType
+      ? sourceCode.getText(funcNode.returnType)
+      : '';
+
+    let newBody: string;
+    if (funcNode.body.type === AST_NODE_TYPES.BlockStatement) {
+      // Body is already a block: { ... }
+      newBody = bodyText;
+    } else {
+      // Body is an expression: need to wrap in { return ...; }
+      newBody = `{ return ${bodyText}; }`;
+    }
+
+    const asyncPrefix = funcNode.async ? 'async ' : '';
+    const replacement = `${asyncPrefix}function ${variableName}${typeParamsText}(${paramsText})${returnTypeText} ${newBody}`;
+
+    return fixer.replaceText(funcNode, replacement);
+  }
+
+  if (funcNode.type === AST_NODE_TYPES.FunctionExpression) {
+    // Anonymous function expression: function() { ... } or function <T>() { ... }
+    // Insert the name after 'function' keyword (before any type parameters)
+    const tokens = sourceCode.getTokens(funcNode);
+    const functionTokenIndex = tokens.findIndex((t) => t.value === 'function');
+    if (functionTokenIndex === -1) {
+      return null;
+    }
+
+    const functionToken = tokens[functionTokenIndex];
+    const nextToken = tokens[functionTokenIndex + 1];
+    if (!nextToken) {
+      return null;
+    }
+
+    // Replace the range between 'function' and the next token (type params or paren)
+    // with the name, handling any existing whitespace
+    return fixer.replaceTextRange(
+      [functionToken.range[1], nextToken.range[0]],
+      ` ${variableName}`,
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Require wrapped components passed to HOCs to be named functions.
+ *
+ * React-related ESLint rules determine whether a function is a React component
+ * by checking the function name. When passing anonymous inline functions (wrapped
+ * components) to HOCs, these rules fail to recognize them as components.
+ *
+ * @see https://legacy.reactjs.org/docs/higher-order-components.html
+ *
+ * @example
+ * // ❌ Invalid - anonymous arrow function
+ * const EnhancedButton = observer(() => <button>Click</button>);
+ *
+ * // ✅ Valid - named function expression
+ * const EnhancedButton = observer(function EnhancedButton() {
+ *   return <button>Click</button>;
+ * });
+ *
+ * // ✅ Valid - reference to named component
+ * const EnhancedButtonBase = () => <button>Click</button>;
+ * const EnhancedButton = observer(EnhancedButtonBase);
+ *
+ * // ✅ Valid - forwardRef exception (unless includeReactHocs is true)
+ * const EnhancedButton = forwardRef((props, ref) => <button ref={ref}>Click</button>);
+ *
+ * // With { includeReactHocs: true }, forwardRef/memo also require named components:
+ * // ❌ Invalid
+ * const EnhancedButton = forwardRef((props, ref) => <button ref={ref}>Click</button>);
+ * // ✅ Valid
+ * const EnhancedButton = forwardRef(function EnhancedButton(props, ref) {
+ *   return <button ref={ref}>Click</button>;
+ * });
+ */
+export const requireNamedWrappedComponentRule = createRule<Options, MessageIds>(
+  {
+    name: basename(__dirname),
+    meta: {
+      docs: {
+        description:
+          'Require wrapped components passed to HOCs to be named functions',
+      },
+      messages: {
+        requireNamedComponent:
+          "Wrapped component passed to '{{hocName}}' must be a named function. Use a named function expression or define the component separately.",
+      },
+      type: 'suggestion',
+      fixable: 'code',
+      schema: [
+        z.toJSONSchema(optionSchema, { target: 'draft-4' }) as JSONSchema4,
+      ],
+      defaultOptions: [{ hocNames: [], includeReactHocs: false }],
+    },
+    defaultOptions: [{ hocNames: [], includeReactHocs: false }],
+    create(context) {
+      const { hocNames: hocNamesArray, includeReactHocs = false } =
+        context.options[0];
+      const hocNames = new Set(hocNamesArray);
+
+      return {
+        CallExpression(node): void {
+          const calleeName = getCalleeName(node.callee);
+          const calleeObjectName = getCalleeObjectName(node.callee);
+          const calleePropertyName = getCalleePropertyName(node.callee);
+
+          // Check if explicitly configured - takes precedence over React HOC exceptions
+          // Matches:
+          // 1. Exact name (e.g., 'observer' or 'React.forwardRef')
+          // 2. Object name (e.g., 'VariantContext' matches 'VariantContext.createComponent')
+          // 3. Property name (e.g., 'createComponent' matches 'AnyContext.createComponent')
+          const isExplicitlyConfigured =
+            (calleeName !== null && hocNames.has(calleeName)) ||
+            (calleeObjectName !== null && hocNames.has(calleeObjectName)) ||
+            (calleePropertyName !== null && hocNames.has(calleePropertyName));
+          const isReactHoc = isExceptionCallee(node.callee);
+
+          // Skip React HOCs (forwardRef, memo) ONLY if not explicitly configured
+          if (!includeReactHocs && isReactHoc && !isExplicitlyConfigured) {
+            return;
+          }
+
+          // Skip if not a configured HOC (and not a React HOC with includeReactHocs)
+          if (!isExplicitlyConfigured && !(includeReactHocs && isReactHoc)) {
+            return;
+          }
+
+          // Check the first argument
+          const firstArg = node.arguments[0];
+          if (!firstArg) {
+            return;
+          }
+
+          // If the first argument is a call expression, check if it's a React HOC
+          // e.g., observer(forwardRef(() => ...)) - the forwardRef call is a React HOC
+          if (firstArg.type === AST_NODE_TYPES.CallExpression) {
+            if (!includeReactHocs && isExceptionCallee(firstArg.callee)) {
+              return;
+            }
+          }
+
+          // Check if the first argument is an anonymous function
+          if (!isAnonymousFunction(firstArg)) {
+            return;
+          }
+
+          const variableName = getVariableName(node);
+
+          context.report({
+            node: firstArg,
+            messageId: 'requireNamedComponent',
+            data: {
+              hocName: calleeName ?? calleeObjectName ?? calleePropertyName,
+            },
+            fix: variableName
+              ? (fixer) =>
+                  generateFix(fixer, context.sourceCode, firstArg, variableName)
+              : undefined,
+          });
+        },
+      };
+    },
+  },
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: 8.56.0
         version: 8.56.0(eslint@10.0.1(jiti@2.6.1))(typescript@5.9.3)
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/core':
         specifier: 'catalog:'
@@ -4593,6 +4596,9 @@ packages:
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@actions/core@3.0.0':
@@ -5722,7 +5728,7 @@ snapshots:
       eslint: 10.0.1(jiti@2.6.1)
       ts-pattern: 5.9.0
       typescript: 5.9.3
-      zod: 4.1.13
+      zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -9394,3 +9400,5 @@ snapshots:
       zod: 4.1.13
 
   zod@4.1.13: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

- Add new ESLint rule `require-named-wrapped-component` that requires wrapped components passed to HOCs (e.g., `observer`, `memo`, `forwardRef`) to be named functions
- This helps React-related ESLint rules (like `react-hooks/rules-of-hooks`) properly recognize components, and improves React DevTools readability by avoiding `Anonymous` / `<Unknown>` labels
- Includes auto-fix support, comprehensive test coverage, and documentation

## Test plan

- [ ] CI passes (build, lint, typecheck, tests)
- [ ] Version plan is included