### PR TITLE
docs: clean up README and add README for packages

### DIFF
--- a/.nx/version-plans/version-plan-1772529604519.md
+++ b/.nx/version-plans/version-plan-1772529604519.md
@@ -1,0 +1,8 @@
+---
+eslint: patch
+prettier-config: patch
+tsconfig: patch
+lint-eslint-config-rules: patch
+---
+
+Add README and LICENSE for packages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ pnpm run typecheck
 pnpm run dev
 
 # Create a version plan before PR (required for PRs with publishable changes)
-pnpm run change
+pnpm -w change
 
 # Check that a version plan exists (used in CI)
 pnpm run check
@@ -79,6 +79,18 @@ Compiled TypeScript outputs to `packages/*/lib/`. Source is in `packages/*/src/`
 - **Test framework**: Vitest
 - **Versioning**: Nx Release with version plans
 
+## Development Workflow
+
+1. Create a `feature/*` branch, make changes, and run `pnpm -w change` to generate a version plan
+2. Open a PR to `main` and merge after review
+3. Merge the automatically created Release PR (`release` → `main`) to publish packages to npm
+
+Additional conventions:
+
+- ESLint uses modern flat config format (`eslint.config.mjs`)
+- Conventional commits are enforced via commitlint
+- Use `pnpm exec` or `pnpm dlx` instead of `npx` for running binaries
+
 ## Nx Release
 
 Versioning uses Nx Release with version plans (markdown files in `.nx/version-plans/`).
@@ -87,12 +99,6 @@ Two release groups:
 
 - **eslint** (fixed) - `eslint-config` and `eslint-plugin` always release together at the same version
 - **other** (independent) - `prettier-config`, `tsconfig`, `lint-eslint-config-rules` release independently
-
-Release flow:
-
-1. Contributors run `pnpm run change` to create a version plan
-2. When version plans or `nx-release-pr` action dist files are pushed to `main`, the `release-pr.yml` workflow creates/updates a release PR on the `release` branch
-3. Merging the release PR (`release` → `main`) triggers `release.yml`, which creates git tags, GitHub releases from changelogs, and publishes to npm with provenance
 
 CI enforcement:
 
@@ -104,11 +110,3 @@ CI enforcement:
 - `feature/*` - Development branches for all changes (features, fixes, refactors, etc.)
 - `renovate/*` - Automated dependency update branches created by Renovate
 - `release` - Holds the Release PR content; created/updated by `release-pr.yml`, merged back into `main` to trigger a release
-
-## Workflow Requirements
-
-- Run `pnpm run change` before creating PRs to generate a version plan (stored in `.nx/version-plans/`)
-- ESLint uses modern flat config format (`eslint.config.mjs`)
-- Conventional commits are enforced via commitlint
-- Releases happen via Release PR workflow (not automatic on main)
-- Use `pnpm exec` or `pnpm dlx` instead of `npx` for running binaries

--- a/README.md
+++ b/README.md
@@ -9,23 +9,24 @@
 
 <!-- Badges area end -->
 
-RightCapital's frontend style guide.
+RightCapital's frontend style guide monorepo — shared configs for ESLint, Prettier, TypeScript, and related tooling.
 
-## Introduction
+## Packages
 
-This repo contains configs for common linting and styling tools widely used in RightCapital.
-
-Following tools are covered:
-
-- [ESLint](#eslint)
-- [Prettier](#prettier)
+| Package                                                                       | Version                                                                                                                                             | Description                                       |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| [`@rightcapital/eslint-config`](packages/eslint-config)                       | [![npm](https://img.shields.io/npm/v/@rightcapital/eslint-config)](https://www.npmjs.com/package/@rightcapital/eslint-config)                       | ESLint flat config with JS, TS, and React support |
+| [`@rightcapital/eslint-plugin`](packages/eslint-plugin)                       | [![npm](https://img.shields.io/npm/v/@rightcapital/eslint-plugin)](https://www.npmjs.com/package/@rightcapital/eslint-plugin)                       | Custom ESLint rules                               |
+| [`@rightcapital/prettier-config`](packages/prettier-config)                   | [![npm](https://img.shields.io/npm/v/@rightcapital/prettier-config)](https://www.npmjs.com/package/@rightcapital/prettier-config)                   | Shared Prettier configuration                     |
+| [`@rightcapital/tsconfig`](packages/tsconfig)                                 | [![npm](https://img.shields.io/npm/v/@rightcapital/tsconfig)](https://www.npmjs.com/package/@rightcapital/tsconfig)                                 | Shared TypeScript configuration                   |
+| [`@rightcapital/lint-eslint-config-rules`](packages/lint-eslint-config-rules) | [![npm](https://img.shields.io/npm/v/@rightcapital/lint-eslint-config-rules)](https://www.npmjs.com/package/@rightcapital/lint-eslint-config-rules) | CLI to check for deprecated/unknown ESLint rules  |
 
 ## ESLint
 
-### Prerequisite
+### Prerequisites
 
-- `eslint`(>=9)
-- `typescript`(optional, for TypeScript support)
+- `eslint` (>=9)
+- `typescript` (optional, for TypeScript support)
 
 ### Usage
 
@@ -35,7 +36,7 @@ Install `@rightcapital/eslint-config` to your project.
 pnpm add -D @rightcapital/eslint-config
 ```
 
-In your `eslint.config.mjs`([or equivalent](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-formats)):
+In your `eslint.config.mjs` ([or equivalent](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-formats)):
 
 ```js
 import eslintConfigRightcapital from '@rightcapital/eslint-config';
@@ -56,163 +57,11 @@ export default defineConfig(
 );
 ```
 
-### Exported configs and utils
-
-**`configs`**
-
-- `recommended`: the all-in-one config, contains multiple rules configs for different files.
-
-> [!NOTE]  
-> The following configs are designed to be used with `extends` option. They do have a preset [`files` option](https://eslint.org/docs/latest/use/configure/configuration-files#:~:text=files%20%2D%20An%20array%20of%20glob%20patterns%20indicating%20the%20files%20that%20the%20configuration%20object%20should%20apply%20to.%20If%20not%20specified%2C%20the%20configuration%20object%20applies%20to%20all%20files%20matched%20by%20any%20other%20configuration%20object.).
-
-- `js`: JavaScript specific config.
-- `ts`: TypeScript specific config.
-- `react`: React specific config.
-- `node`: Node.js specific config.
-- `script`: Script oriented config, with less strict rules.
-- `disableExpensiveRules`: Disable type-aware rules and `import-x/no-cycle` to speed up linting. Useful in git hooks or `lint-staged`.
-
-**`utils`**
-
-- `defineConfig`: reexported util from `typescript-eslint` for easier compositing ESLint config. (docs: https://typescript-eslint.io/packages/typescript-eslint#config), with automatic plugin inference (when the plugin is known to `@rightcapital/eslint-config`).
-
-  ```js
-  const { defineConfig } = eslintConfigRightcapital.utils;
-
-  export default defineConfig({
-    plugins: {
-      /**
-       * You can omit this since it's already known to `@rightcapital/eslint-config`.
-       * And `defineConfig` will automatically infer the plugin from `@rightcapital/eslint-config`.
-       */
-      // unicorn: eslintPluginUnicorn,
-    },
-    rules: {
-      'unicorn/no-hex-escape': 'error',
-    },
-  });
-  ```
-
-- `globals`: reexported util from [globals](https://github.com/sindresorhus/globals), useful for configuring [`languageOptions.globals`](https://eslint.org/docs/latest/use/configure/language-options#specifying-globals).
-- `isInGitHooksOrLintStaged`: return a boolean to indicate whether current environment is in git hooks or `lint-staged`.
-
----
-
-<details>
-<summary>
-<b>[Deprecated]</b> Usage for Legacy ESLint versions(&lt;9)
-</summary>
-
-There are following config packages for legacy ESLint versions(<9):
-
-- `@rightcapital/eslint-config-javascript`: for JavaScript files
-- `@rightcapital/eslint-config-typescript`: for TypeScript files
-- `@rightcapital/eslint-config-typescript-react`: for TypeScript + React files
-- `@rightcapital/eslint-plugin`
-
-They can be used independently or combined together according to your project's needs.
-
-Install the config package(s) you need:
-
-```sh
-# e.g. for a project only using JavaScript
-pnpm add -D @rightcapital/eslint-config-javascript
-```
-
-In your `.eslintrc.cjs`([or equivalent](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-formats)):
-
-1. [using `overrides` to group different types of files](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-based-on-glob-patterns), and extends the corresponding config.
-2. Add proper `env` and other configs if needed.
-
-```js .eslintrc.cjs
-/** @type {import("eslint").Linter.Config} */
-module.exports = {
-  // use overrides to group different types of files
-  // see https://eslint.org/docs/latest/use/configure/configuration-files#configuration-based-on-glob-patterns
-  overrides: [
-    {
-      // typical TypeScript React code, running in browser
-      files: ['src/**/*.{ts,tsx}'],
-      excludedFiles: ['src/**/*.test.{ts,tsx}'], // exclude test files
-      extends: ['@rightcapital/typescript-react'],
-      env: { browser: true },
-    },
-  ],
-};
-```
-
-> [!NOTE]  
-> Applying same config to all files in the project could be error-prone. Not recommended.
-
-#### Complete Showcase
-
-<details>
-<summary>
-For example, we have a project with the following structure:
-</summary>
-
-```
-.
-├── .eslintrc.cjs
-├── jest.config.cjs
-├── prettier.config.cjs
-├── scripts      <---------------- Various scripts running in Node.js
-│   ├── brew-coffee.ts
-│   ├── make-latte.mjs
-│   └── print-project-stats.tsx
-└── src
-    ├── App.test.ts  <------------ Jest test file
-    └── App.tsx      <------------ TypeScript React component
-```
-
-The `.eslintrc.cjs` could look like this:
-
-```js
-/** @type {import("eslint").Linter.Config} */
-module.exports = {
-  // usually `true` for project root config
-  // see https://eslint.org/docs/latest/use/configure/configuration-files#cascading-and-hierarchy
-  root: true,
-
-  // use overrides to group different types of files
-  // see https://eslint.org/docs/latest/use/configure/configuration-files#configuration-based-on-glob-patterns
-  overrides: [
-    {
-      // typical TypeScript React code, running in browser
-      files: ['src/**/*.{ts,tsx}'],
-      excludedFiles: ['src/**/*.test.{ts,tsx}'], // exclude test files
-      extends: ['@rightcapital/typescript-react'],
-      env: { browser: true },
-    },
-    {
-      // test files
-      files: ['src/**/*.test.{ts,tsx}'],
-      extends: ['@rightcapital/typescript-react'],
-      env: { jest: true, node: true },
-    },
-    {
-      // JavaScript config and scripts
-      files: ['./*.{js,cjs,mjs,jsx}', 'scripts/**/*.{js,cjs,mjs,jsx}'],
-      excludedFiles: ['src/**'],
-      extends: ['@rightcapital/javascript'],
-      env: { node: true },
-    },
-    {
-      // TypeScript config and scripts
-      files: ['./*.{ts,cts,mts,tsx}', 'scripts/**/*.{ts,cts,mts,tsx}'],
-      excludedFiles: ['src/**'],
-      env: { node: true },
-    },
-  ],
-};
-```
-
-</details>
-</details>
+See [`packages/eslint-config`](packages/eslint-config) for the full list of exported configs and utils.
 
 ## Prettier
 
-### Prerequisite
+### Prerequisites
 
 - `prettier`
 
@@ -220,7 +69,7 @@ module.exports = {
 
 Install config package to your project:
 
-```bash
+```sh
 pnpm add -D @rightcapital/prettier-config
 ```
 
@@ -229,6 +78,14 @@ In your project's `prettier.config.cjs`:
 ```js
 module.exports = require('@rightcapital/prettier-config');
 ```
+
+See [`packages/prettier-config`](packages/prettier-config) for details.
+
+## Development
+
+1. Create a `feature/*` branch, make changes, and run `pnpm -w change` to generate a version plan
+2. Open a PR to `main` and merge after review
+3. Merge the automatically created Release PR to publish packages to npm
 
 ## License
 

--- a/packages/eslint-config/LICENSE
+++ b/packages/eslint-config/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 RightCapital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,0 +1,83 @@
+# @rightcapital/eslint-config
+
+[![npm version](https://img.shields.io/npm/v/@rightcapital/eslint-config)](https://www.npmjs.com/package/@rightcapital/eslint-config)
+
+RightCapital's ESLint [flat config](https://eslint.org/docs/latest/use/configure/configuration-files) with support for JavaScript, TypeScript, and React.
+
+## Prerequisites
+
+- `eslint` (9.x or 10.x)
+- `typescript` (5.x, optional — for TypeScript support)
+
+## Installation
+
+```sh
+pnpm add -D @rightcapital/eslint-config
+```
+
+## Usage
+
+In your `eslint.config.mjs` ([or equivalent](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-formats)):
+
+```js
+import eslintConfigRightcapital from '@rightcapital/eslint-config';
+
+const { defineConfig } = eslintConfigRightcapital.utils;
+
+export default defineConfig(
+  ...eslintConfigRightcapital.configs.recommended,
+
+  // add more configs for specific files or packages if needed
+  {
+    files: ['scripts/**/*.{js,cjs,mjs}'],
+    extends: [
+      ...eslintConfigRightcapital.configs.node,
+      ...eslintConfigRightcapital.configs.script,
+    ],
+  },
+);
+```
+
+## Exported configs and utils
+
+### `configs`
+
+- `recommended` — the all-in-one config, contains multiple rules configs for different file types.
+
+> [!NOTE]
+> The following configs are designed to be used with the `extends` option. They have a preset [`files` option](https://eslint.org/docs/latest/use/configure/configuration-files#:~:text=files%20%2D%20An%20array%20of%20glob%20patterns%20indicating%20the%20files%20that%20the%20configuration%20object%20should%20apply%20to.%20If%20not%20specified%2C%20the%20configuration%20object%20applies%20to%20all%20files%20matched%20by%20any%20other%20configuration%20object.).
+
+- `js` — JavaScript specific config.
+- `ts` — TypeScript specific config.
+- `react` — React specific config.
+- `node` — Node.js specific config.
+- `script` — Script oriented config, with less strict rules.
+- `disableExpensiveRules` — Disable type-aware rules and `import-x/no-cycle` to speed up linting. Useful in git hooks or `lint-staged`.
+
+### `utils`
+
+- `defineConfig` — re-exported util from [`typescript-eslint`](https://typescript-eslint.io/packages/typescript-eslint#config) for easier compositing of ESLint config, with automatic plugin inference (when the plugin is known to `@rightcapital/eslint-config`).
+
+  ```js
+  const { defineConfig } = eslintConfigRightcapital.utils;
+
+  export default defineConfig({
+    plugins: {
+      /**
+       * You can omit this since it's already known to `@rightcapital/eslint-config`.
+       * `defineConfig` will automatically infer the plugin.
+       */
+      // unicorn: eslintPluginUnicorn,
+    },
+    rules: {
+      'unicorn/no-hex-escape': 'error',
+    },
+  });
+  ```
+
+- `globals` — re-exported util from [globals](https://github.com/sindresorhus/globals), useful for configuring [`languageOptions.globals`](https://eslint.org/docs/latest/use/configure/language-options#specifying-globals).
+- `isInGitHooksOrLintStaged` — returns a boolean indicating whether the current environment is in git hooks or `lint-staged`.
+
+## License
+
+[MIT License](./LICENSE) © 2023-Present

--- a/packages/eslint-plugin/.npmignore
+++ b/packages/eslint-plugin/.npmignore
@@ -1,5 +1,7 @@
 *
 !/lib/**
+!/LICENSE
+!/README.md
 /lib/**/*.test.js
 /lib/**/*.test.d.ts
 /lib/**/*.test.js.map

--- a/packages/eslint-plugin/LICENSE
+++ b/packages/eslint-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 RightCapital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,5 +1,44 @@
 # @rightcapital/eslint-plugin
 
+[![npm version](https://img.shields.io/npm/v/@rightcapital/eslint-plugin)](https://www.npmjs.com/package/@rightcapital/eslint-plugin)
+
+Custom ESLint rules used at RightCapital.
+
+## Installation
+
+```sh
+pnpm add -D @rightcapital/eslint-plugin
+```
+
+> [!NOTE]
+> If you use [`@rightcapital/eslint-config`](https://www.npmjs.com/package/@rightcapital/eslint-config), this plugin is already included — no separate installation needed.
+
+## Usage
+
+If you're using `@rightcapital/eslint-config`, the plugin's recommended rules are enabled automatically. For manual configuration:
+
+```js
+import rightcapitalPlugin from '@rightcapital/eslint-plugin';
+
+export default [
+  {
+    plugins: {
+      '@rightcapital': rightcapitalPlugin,
+    },
+    rules: {
+      '@rightcapital/jsx-no-unused-expressions': 'error',
+    },
+  },
+];
+```
+
+## Configs
+
+- `recommended-jsx` — recommended rules for JSX files.
+- `recommended-react` — recommended rules for React files (includes `recommended-jsx`).
+
+## Rules
+
 <!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.\
@@ -7,10 +46,14 @@
 ✅ Set in the `recommended-react` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                                                                                                                  | Description                                                                                                     | 💼    | 🔧  |
-| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- | :---- | :-- |
-| [jsx-no-unused-expressions](src/rules/jsx-no-unused-expressions/jsx-no-unused-expressions.md)                                                                         | Disallow unused JSX expressions                                                                                 | ☑️ ✅ |     |
-| [no-explicit-type-on-function-component-identifier](src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.md) | Disallow explicitly specifying type for function component identifier. (This rule requires `typescript-eslint`) |       | 🔧  |
-| [no-ignore-return-value-of-react-hooks](src/rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks.md)                                     | Disallow ignoring return value of React hooks.                                                                  | ✅    |     |
+| Name                                                                                                                                                                                                                                                          | Description                                                                                                     | 💼    | 🔧  |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- | :---- | :-- |
+| [jsx-no-unused-expressions](https://github.com/RightCapitalHQ/frontend-style-guide/blob/main/packages/eslint-plugin/src/rules/jsx-no-unused-expressions/jsx-no-unused-expressions.md)                                                                         | Disallow unused JSX expressions                                                                                 | ☑️ ✅ |     |
+| [no-explicit-type-on-function-component-identifier](https://github.com/RightCapitalHQ/frontend-style-guide/blob/main/packages/eslint-plugin/src/rules/no-explicit-type-on-function-component-identifier/no-explicit-type-on-function-component-identifier.md) | Disallow explicitly specifying type for function component identifier. (This rule requires `typescript-eslint`) |       | 🔧  |
+| [no-ignore-return-value-of-react-hooks](https://github.com/RightCapitalHQ/frontend-style-guide/blob/main/packages/eslint-plugin/src/rules/no-ignore-return-value-of-react-hooks/no-ignore-return-value-of-react-hooks.md)                                     | Disallow ignoring return value of React hooks.                                                                  | ✅    |     |
 
 <!-- end auto-generated rules list -->
+
+## License
+
+[MIT License](./LICENSE) © 2023-Present

--- a/packages/lint-eslint-config-rules/.npmignore
+++ b/packages/lint-eslint-config-rules/.npmignore
@@ -1,0 +1,4 @@
+src/
+project.json
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/lint-eslint-config-rules/LICENSE
+++ b/packages/lint-eslint-config-rules/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 RightCapital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/lint-eslint-config-rules/README.md
+++ b/packages/lint-eslint-config-rules/README.md
@@ -1,5 +1,39 @@
 # @rightcapital/lint-eslint-config-rules
 
+[![npm version](https://img.shields.io/npm/v/@rightcapital/lint-eslint-config-rules)](https://www.npmjs.com/package/@rightcapital/lint-eslint-config-rules)
+
+A CLI tool that checks your ESLint configuration for deprecated and unknown rules.
+
+## Prerequisites
+
+- `eslint` (9.x or 10.x)
+
+## Usage
+
 ```sh
 npx @rightcapital/lint-eslint-config-rules
 ```
+
+## Options
+
+| Option         | Description                            |
+| -------------- | -------------------------------------- |
+| `-h`, `--help` | Display help message                   |
+| `--cwd <path>` | The directory to lint (default: `cwd`) |
+| `--json`       | Output all information in JSON format  |
+| `--version`    | Display version number                 |
+
+## Example output
+
+```
+Checking ESLint rules in /path/to/project
+Discovered 250/500 used/available rules
+No used deprecated rules found
+No used unknown rules found
+```
+
+The process exits with code 1 if any deprecated or unknown rules are found, making it suitable for CI pipelines.
+
+## License
+
+[MIT License](./LICENSE) © 2023-Present

--- a/packages/prettier-config/LICENSE
+++ b/packages/prettier-config/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 RightCapital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,0 +1,37 @@
+# @rightcapital/prettier-config
+
+[![npm version](https://img.shields.io/npm/v/@rightcapital/prettier-config)](https://www.npmjs.com/package/@rightcapital/prettier-config)
+
+RightCapital's shared [Prettier](https://prettier.io/) configuration.
+
+## Prerequisites
+
+- `prettier` (^3.0.0)
+
+## Installation
+
+```sh
+pnpm add -D @rightcapital/prettier-config
+```
+
+## Usage
+
+In your `prettier.config.cjs`:
+
+```js
+module.exports = require('@rightcapital/prettier-config');
+```
+
+## What's included
+
+- Single quotes
+- Semicolons
+- 2-space indentation
+- 80-character print width
+- Trailing commas (all)
+- Arrow function parentheses (always)
+- [`prettier-plugin-packagejson`](https://github.com/matzkoh/prettier-plugin-packagejson) for sorting `package.json`
+
+## License
+
+[MIT License](./LICENSE) © 2023-Present

--- a/packages/tsconfig/LICENSE
+++ b/packages/tsconfig/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 RightCapital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,0 +1,38 @@
+# @rightcapital/tsconfig
+
+[![npm version](https://img.shields.io/npm/v/@rightcapital/tsconfig)](https://www.npmjs.com/package/@rightcapital/tsconfig)
+
+RightCapital's shared [TypeScript](https://www.typescriptlang.org/) configuration.
+
+## Installation
+
+```sh
+pnpm add -D @rightcapital/tsconfig
+```
+
+## Usage
+
+In your `tsconfig.json`:
+
+```json
+{
+  "extends": "@rightcapital/tsconfig"
+}
+```
+
+## What's included
+
+- `strict` mode enabled
+- `target`: ESNext
+- `module`: NodeNext
+- `verbatimModuleSyntax`: enabled
+- `resolveJsonModule`: enabled
+- `composite`: enabled
+- `sourceMap` and `declarationMap`: enabled
+- `skipLibCheck`: enabled
+- `forceConsistentCasingInFileNames`: enabled
+- `allowSyntheticDefaultImports`: enabled
+
+## License
+
+[MIT License](./LICENSE) © 2023-Present


### PR DESCRIPTION
## Summary

- Clean up root `README.md`: replace the lengthy inline docs with a concise packages table and quick-start sections for ESLint and Prettier
- Add per-package `README.md` with full usage docs, exported configs/utils reference, and examples
- Add `LICENSE` files to each package for proper npm publishing
- Add `.npmignore` to `eslint-plugin` and `lint-eslint-config-rules` to exclude unnecessary files from the published package

## Test plan

- [x] Verify root README renders correctly with packages table, ESLint and Prettier quick-start sections, and links to per-package docs
- [x] Verify each package README renders correctly on GitHub and will display on npmjs.com
- [x] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)