### PR TITLE
ci: migrate prerelease to release.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,13 @@ jobs:
       - name: Check and generate version plan for Renovate
         uses: ./.github/actions/renovate-auto-version-plan
 
-  publish:
-    if: ${{ always() && !failure() && !cancelled() }}
+  prerelease:
+    if: >-
+      !failure() && !cancelled()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == 'RightCapitalHQ/frontend-style-guide'
+      && github.base_ref == github.event.repository.default_branch
+      && github.head_ref != 'release'
     needs:
       [
         test,
@@ -112,26 +117,13 @@ jobs:
         check-renovate-version-plan,
         check-workflow-files,
       ]
-    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-      - run: pnpm install
-
-      - name: Publish (development)
-        if: github.event.pull_request.head.repo.full_name == 'RightCapitalHQ/frontend-style-guide' && github.base_ref == github.event.repository.default_branch
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          preid="${HEAD_REF//\//-}".${{ github.run_number }}.${{ github.run_attempt }}
-          pnpm --filter './packages/*' exec npm --no-git-tag-version version prerelease --preid="${preid}"
-          pnpm --filter './packages/*' publish --no-git-checks --access public --tag development
+    uses: ./.github/workflows/release.yml
+    with:
+      prerelease: true
+      branch_name: ${{ github.head_ref }}
+      run_number: ${{ github.run_number }}
+      run_attempt: ${{ github.run_attempt }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,27 @@ on:
     types: [closed]
     branches: [main]
 
+  workflow_call:
+    inputs:
+      prerelease:
+        required: true
+        type: boolean
+      branch_name:
+        required: true
+        type: string
+      run_number:
+        required: true
+        type: string
+      run_attempt:
+        required: true
+        type: string
+
 jobs:
   release:
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'release'
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && github.event.pull_request.head.ref == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -96,3 +114,33 @@ jobs:
         run: pnpm exec nx release publish
         env:
           NPM_CONFIG_PROVENANCE: true
+
+  prerelease:
+    if: >-
+      github.event_name == 'workflow_call'
+      && inputs.prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org/
+          cache: pnpm
+      - run: pnpm install
+
+      - name: Publish prerelease (development)
+        env:
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          RUN_NUMBER: ${{ inputs.run_number }}
+          RUN_ATTEMPT: ${{ inputs.run_attempt }}
+        run: |
+          preid="${BRANCH_NAME//\//-}".${RUN_NUMBER}.${RUN_ATTEMPT}
+          pnpm --filter './packages/*' exec npm --no-git-tag-version version prerelease --preid="${preid}"
+          pnpm --filter './packages/*' publish --no-git-checks --access public --tag development


### PR DESCRIPTION
## Summary

- Migrate prerelease publish logic from `ci.yml` to `release.yml` by making `release.yml` a reusable workflow (`workflow_call`)
- Fix npm trusted publishing (OIDC) failure: npm is configured to only accept publishes from `release.yml`, but prereleases were running in `ci.yml` — with `workflow_call`, the OIDC `job_workflow_ref` claim points to the **called** workflow (`release.yml`), satisfying npm's config
- Pass `run_number` and `run_attempt` through `env:` instead of direct `${{ }}` interpolation to prevent script injection

## Changes

### `release.yml`
- Add `workflow_call` trigger with `prerelease`, `branch_name`, `run_number`, `run_attempt` inputs
- Guard existing `release` job with `github.event_name == 'pull_request'` so it won't run during `workflow_call`
- Add new `prerelease` job (gated on `workflow_call` + `inputs.prerelease`)

### `ci.yml`
- Replace `publish` job with `prerelease` job that calls `release.yml` as a reusable workflow
- Consolidate step-level conditions into job-level `if`
- Add `github.head_ref != 'release'` guard to skip prerelease on the release PR

## Test plan

- [ ] Open a PR to main → `prerelease` job in CI calls `release.yml` and publishes `development`-tagged packages to npm
- [ ] Verify production release flow is unaffected (the `release` job conditions are mutually exclusive with `prerelease`)
- [ ] `check-workflow-files` job validates workflow syntax via actionlint