### PR TITLE
feat(eslint-config): relax/remove legacy Airbnb-era rules

### DIFF
--- a/.nx/version-plans/version-plan-1776680646969.md
+++ b/.nx/version-plans/version-plan-1776680646969.md
@@ -1,0 +1,30 @@
+---
+eslint: minor
+---
+
+relax/remove legacy Airbnb-era rules
+
+A large portion of the rules in `packages/eslint-config/src/config/base/*` were lifted from `eslint-config-airbnb-base@15.0.0` and reflect ES5 / pre-Prettier / pre-TypeScript defensive defaults. With Node 24 and modern browsers as the baseline, many of those rules are dead, redundant with TypeScript or other plugins, or fight idiomatic modern code. See #373 for the full discussion.
+
+Rules removed (turned off):
+
+- `no-continue`, `func-names` (modern style)
+- `vars-on-top`, `block-scoped-var`, `no-loop-func` (dead given `no-var`)
+- `no-with`, `no-iterator`, `no-proto`, `no-buffer-constructor` (banned in strict mode / removed from runtime / deprecated upstream)
+- `max-classes-per-file` (noisy for legitimate utility helpers)
+- `guard-for-in` (duplicate of existing `no-restricted-syntax` ban on `for…in`)
+
+Rules relaxed:
+
+- `no-plusplus` → allow in for-loop afterthoughts
+- `no-underscore-dangle` → allow after `this`
+- `no-restricted-properties` → drop the `Math.pow` entry (already covered by `prefer-exponentiation-operator`)
+- `new-cap` → drop the `Immutable.*` exceptions (Immutable.js is no longer used)
+- `no-param-reassign` → drop the `$scope` (Angular 1.x) and `staticContext` (legacy `react-router`) entries
+- `@typescript-eslint/naming-convention` → drop the legacy `^I[A-Z]` Hungarian-notation interface rule; keep PascalCase enforcement for interfaces
+
+TypeScript-only overrides (kept on for JS files):
+
+- `no-throw-literal` off in TS — covered by typed-aware `@typescript-eslint/only-throw-error`
+- `no-array-constructor` off in TS — covered by `@typescript-eslint/no-array-constructor`
+- `no-undef` off in TS — TypeScript itself catches it; typescript-eslint explicitly recommends disabling for TS files

--- a/packages/eslint-config/src/config/base/best-practices.ts
+++ b/packages/eslint-config/src/config/base/best-practices.ts
@@ -12,10 +12,6 @@ const config: readonly ConfigObject[] = [
       // https://eslint.org/docs/rules/array-callback-return
       'array-callback-return': ['error', { allowImplicit: true }],
 
-      // treat var statements as if they were block scoped
-      // https://eslint.org/docs/rules/block-scoped-var
-      'block-scoped-var': 'error',
-
       // require return statements to either always or never specify values
       // https://eslint.org/docs/rules/consistent-return
       'consistent-return': 'error',
@@ -47,14 +43,6 @@ const config: readonly ConfigObject[] = [
         'anyOrder',
         { enforceForTSTypes: true },
       ],
-
-      // make sure for-in loops have an if statement
-      // https://eslint.org/docs/rules/guard-for-in
-      'guard-for-in': 'error',
-
-      // enforce a maximum number of classes per file
-      // https://eslint.org/docs/rules/max-classes-per-file
-      'max-classes-per-file': ['error', 1],
 
       // disallow the use of alert, confirm, and prompt
       // https://eslint.org/docs/rules/no-alert
@@ -117,10 +105,6 @@ const config: readonly ConfigObject[] = [
       // https://eslint.org/docs/rules/no-implied-eval
       'no-implied-eval': 'error',
 
-      // disallow usage of __iterator__ property
-      // https://eslint.org/docs/rules/no-iterator
-      'no-iterator': 'error',
-
       // disallow use of labels for anything other than loops and switches
       // https://eslint.org/docs/rules/no-labels
       'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
@@ -128,10 +112,6 @@ const config: readonly ConfigObject[] = [
       // disallow unnecessary nested blocks
       // https://eslint.org/docs/rules/no-lone-blocks
       'no-lone-blocks': 'error',
-
-      // disallow creation of functions within loops
-      // https://eslint.org/docs/rules/no-loop-func
-      'no-loop-func': 'error',
 
       // disallow use of multiline strings
       // https://eslint.org/docs/rules/no-multi-str
@@ -179,15 +159,9 @@ const config: readonly ConfigObject[] = [
             'request', // for Express requests
             'res', // for Express responses
             'response', // for Express responses
-            '$scope', // for Angular 1 scopes
-            'staticContext', // for ReactRouter context
           ],
         },
       ],
-
-      // disallow usage of __proto__ property
-      // https://eslint.org/docs/rules/no-proto
-      'no-proto': 'error',
 
       // disallow declaring the same variable more than once
       // https://eslint.org/docs/rules/no-redeclare
@@ -239,11 +213,6 @@ const config: readonly ConfigObject[] = [
         {
           property: '__defineSetter__',
           message: 'Please use Object.defineProperty instead.',
-        },
-        {
-          object: 'Math',
-          property: 'pow',
-          message: 'Use the exponentiation operator (**) instead.',
         },
       ],
 
@@ -311,10 +280,6 @@ const config: readonly ConfigObject[] = [
       // https://eslint.org/docs/rules/no-void
       'no-void': 'error',
 
-      // disallow use of the with statement
-      // https://eslint.org/docs/rules/no-with
-      'no-with': 'error',
-
       // require using Error objects as Promise rejection reasons
       // https://eslint.org/docs/rules/prefer-promise-reject-errors
       'prefer-promise-reject-errors': ['error', { allowEmptyReject: true }],
@@ -330,10 +295,6 @@ const config: readonly ConfigObject[] = [
       // require use of the second argument for parseInt()
       // https://eslint.org/docs/rules/radix
       radix: 'error',
-
-      // requires to declare all vars on top of their containing scope
-      // https://eslint.org/docs/rules/vars-on-top
-      'vars-on-top': 'error',
 
       // require or disallow Yoda conditions
       // https://eslint.org/docs/rules/yoda

--- a/packages/eslint-config/src/config/base/style.ts
+++ b/packages/eslint-config/src/config/base/style.ts
@@ -12,10 +12,6 @@ const config: readonly ConfigObject[] = [
       // require camel case names
       camelcase: ['error', { properties: 'never', ignoreDestructuring: false }],
 
-      // require function expressions to have a name
-      // https://eslint.org/docs/rules/func-names
-      'func-names': 'warn',
-
       // require an empty line between class members
       // https://eslint.style/rules/default/lines-between-class-members
       '@stylistic/lines-between-class-members': ['error', 'always'],
@@ -48,11 +44,6 @@ const config: readonly ConfigObject[] = [
           newIsCap: true,
           newIsCapExceptions: [],
           capIsNew: false,
-          capIsNewExceptions: [
-            'Immutable.Map',
-            'Immutable.Set',
-            'Immutable.List',
-          ],
         },
       ],
 
@@ -62,10 +53,6 @@ const config: readonly ConfigObject[] = [
       // disallow use of bitwise operators
       // https://eslint.org/docs/rules/no-bitwise
       'no-bitwise': 'error',
-
-      // disallow use of the continue statement
-      // https://eslint.org/docs/rules/no-continue
-      'no-continue': 'error',
 
       // disallow if as the only statement in an else block
       // https://eslint.org/docs/rules/no-lonely-if
@@ -82,9 +69,9 @@ const config: readonly ConfigObject[] = [
       // https://eslint.org/docs/latest/rules/no-object-constructor
       'no-object-constructor': 'error',
 
-      // disallow use of unary operators, ++ and --
+      // disallow use of unary operators, ++ and -- (allowed in for-loop afterthoughts)
       // https://eslint.org/docs/rules/no-plusplus
-      'no-plusplus': 'error',
+      'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
 
       // disallow certain syntax forms
       // https://eslint.org/docs/rules/no-restricted-syntax
@@ -113,13 +100,13 @@ const config: readonly ConfigObject[] = [
         },
       ],
 
-      // disallow dangling underscores in identifiers
+      // disallow dangling underscores in identifiers (allowed after `this`)
       // https://eslint.org/docs/rules/no-underscore-dangle
       'no-underscore-dangle': [
         'error',
         {
           allow: [],
-          allowAfterThis: false,
+          allowAfterThis: true,
           allowAfterSuper: false,
           enforceInMethodNames: true,
         },

--- a/packages/eslint-config/src/config/mixin/node.ts
+++ b/packages/eslint-config/src/config/mixin/node.ts
@@ -20,10 +20,6 @@ const config: readonly ConfigObject[] = [
       // https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/global-require.md
       'n/global-require': 'error',
 
-      // disallow use of the Buffer() constructor
-      // https://eslint.org/docs/rules/no-buffer-constructor
-      'no-buffer-constructor': 'error',
-
       // disallow use of new operator with the require function
       // https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-new-require.md
       'n/no-new-require': 'error',

--- a/packages/eslint-config/src/config/typescript.ts
+++ b/packages/eslint-config/src/config/typescript.ts
@@ -79,16 +79,13 @@ const editorConfig: readonly ConfigObject[] = [
       // https://typescript-eslint.io/rules/no-non-null-assertion
       '@typescript-eslint/no-non-null-assertion': 'error',
 
+      // enforce PascalCase for interface names (core `camelcase` only bans snake_case)
+      // https://typescript-eslint.io/rules/naming-convention/
       '@typescript-eslint/naming-convention': [
         'error',
         {
-          // interface starts with `I`
           selector: 'interface',
           format: ['PascalCase'],
-          custom: {
-            regex: '^I[A-Z]',
-            match: true,
-          },
         },
       ],
 
@@ -98,6 +95,19 @@ const editorConfig: readonly ConfigObject[] = [
       // https://typescript-eslint.io/rules/no-shadow/
       'no-shadow': 'off',
       '@typescript-eslint/no-shadow': 'error',
+
+      // covered by typed-aware `@typescript-eslint/only-throw-error` from `recommendedTypeChecked`
+      // https://typescript-eslint.io/rules/only-throw-error/
+      'no-throw-literal': 'off',
+
+      // covered by `@typescript-eslint/no-array-constructor` from `typescript-eslint/recommended`
+      // https://typescript-eslint.io/rules/no-array-constructor/
+      'no-array-constructor': 'off',
+
+      // TypeScript itself catches references to undeclared variables;
+      // typescript-eslint explicitly recommends disabling `no-undef` for TS files
+      // https://typescript-eslint.io/troubleshooting/typed-linting/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+      'no-undef': 'off',
 
       // https://typescript-eslint.io/rules/no-empty-function/
       'no-empty-function': 'off',

--- a/specs/eslint-configs/tests/__snapshots__/presets.test.mts.snap
+++ b/specs/eslint-configs/tests/__snapshots__/presets.test.mts.snap
@@ -89,9 +89,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
         "checkForEach": false,
       },
     ],
-    "block-scoped-var": [
-      2,
-    ],
     "camelcase": [
       2,
       {
@@ -141,11 +138,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
     "for-direction": [
       2,
     ],
-    "func-names": [
-      1,
-      "always",
-      {},
-    ],
     "getter-return": [
       2,
       {
@@ -158,9 +150,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       {
         "enforceForTSTypes": true,
       },
-    ],
-    "guard-for-in": [
-      2,
     ],
     "import-x/export": [
       2,
@@ -256,18 +245,22 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       2,
       "never",
     ],
-    "max-classes-per-file": [
-      2,
-      1,
-    ],
     "new-cap": [
       2,
       {
         "capIsNew": false,
         "capIsNewExceptions": [
-          "Immutable.Map",
-          "Immutable.Set",
-          "Immutable.List",
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt",
         ],
         "newIsCap": true,
         "newIsCapExceptions": [],
@@ -323,9 +316,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       },
     ],
     "no-constructor-return": [
-      2,
-    ],
-    "no-continue": [
       2,
     ],
     "no-control-regex": [
@@ -451,9 +441,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
         "skipTemplates": false,
       },
     ],
-    "no-iterator": [
-      2,
-    ],
     "no-label-var": [
       2,
     ],
@@ -468,9 +455,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       2,
     ],
     "no-lonely-if": [
-      2,
-    ],
-    "no-loop-func": [
       2,
     ],
     "no-loss-of-precision": [
@@ -534,8 +518,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
           "request",
           "res",
           "response",
-          "$scope",
-          "staticContext",
         ],
         "props": true,
       },
@@ -543,7 +525,7 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
     "no-plusplus": [
       2,
       {
-        "allowForLoopAfterthoughts": false,
+        "allowForLoopAfterthoughts": true,
       },
     ],
     "no-promise-executor-return": [
@@ -551,9 +533,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       {
         "allowVoid": false,
       },
-    ],
-    "no-proto": [
-      2,
     ],
     "no-prototype-builtins": [
       2,
@@ -690,11 +669,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
         "message": "Please use Object.defineProperty instead.",
         "property": "__defineSetter__",
       },
-      {
-        "message": "Use the exponentiation operator (**) instead.",
-        "object": "Math",
-        "property": "pow",
-      },
     ],
     "no-restricted-syntax": [
       2,
@@ -783,7 +757,7 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       {
         "allow": [],
         "allowAfterSuper": false,
-        "allowAfterThis": false,
+        "allowAfterThis": true,
         "allowAfterThisConstructor": false,
         "allowFunctionParams": true,
         "allowInArrayDestructuring": true,
@@ -904,9 +878,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
       {
         "allowAsStatement": false,
       },
-    ],
-    "no-with": [
-      2,
     ],
     "object-shorthand": [
       2,
@@ -1039,9 +1010,6 @@ exports[`Resolved config matches snapshot > javascript.js 1`] = `
         "requireStringLiterals": true,
       },
     ],
-    "vars-on-top": [
-      2,
-    ],
     "yoda": [
       2,
       "never",
@@ -1080,7 +1048,7 @@ exports[`Resolved config matches snapshot > javascript.js 2`] = `
 "- Editor mode: false  - 3
 + Editor mode: true   + 0
 
-@@ -1011,13 +1011,10 @@
+@@ -982,13 +982,10 @@
         2,
         Object {
           "withDash": false,
@@ -1214,10 +1182,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     "@typescript-eslint/naming-convention": [
       2,
       {
-        "custom": {
-          "match": true,
-          "regex": "^I[A-Z]",
-        },
         "format": [
           "PascalCase",
         ],
@@ -1399,9 +1363,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
         "checkForEach": false,
       },
     ],
-    "block-scoped-var": [
-      2,
-    ],
     "camelcase": [
       2,
       {
@@ -1451,11 +1412,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     "for-direction": [
       2,
     ],
-    "func-names": [
-      1,
-      "always",
-      {},
-    ],
     "getter-return": [
       0,
       {
@@ -1468,9 +1424,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
       {
         "enforceForTSTypes": true,
       },
-    ],
-    "guard-for-in": [
-      2,
     ],
     "import-x/export": [
       2,
@@ -1569,18 +1522,22 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
       2,
       "never",
     ],
-    "max-classes-per-file": [
-      2,
-      1,
-    ],
     "new-cap": [
       2,
       {
         "capIsNew": false,
         "capIsNewExceptions": [
-          "Immutable.Map",
-          "Immutable.Set",
-          "Immutable.List",
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt",
         ],
         "newIsCap": true,
         "newIsCapExceptions": [],
@@ -1636,9 +1593,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
       },
     ],
     "no-constructor-return": [
-      2,
-    ],
-    "no-continue": [
       2,
     ],
     "no-control-regex": [
@@ -1764,9 +1718,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
         "skipTemplates": false,
       },
     ],
-    "no-iterator": [
-      2,
-    ],
     "no-label-var": [
       2,
     ],
@@ -1781,9 +1732,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
       2,
     ],
     "no-lonely-if": [
-      2,
-    ],
-    "no-loop-func": [
       2,
     ],
     "no-loss-of-precision": [
@@ -1850,8 +1798,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
           "request",
           "res",
           "response",
-          "$scope",
-          "staticContext",
         ],
         "props": true,
       },
@@ -1859,7 +1805,7 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
     "no-plusplus": [
       2,
       {
-        "allowForLoopAfterthoughts": false,
+        "allowForLoopAfterthoughts": true,
       },
     ],
     "no-promise-executor-return": [
@@ -1867,9 +1813,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
       {
         "allowVoid": false,
       },
-    ],
-    "no-proto": [
-      2,
     ],
     "no-prototype-builtins": [
       2,
@@ -2006,11 +1949,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
         "message": "Please use Object.defineProperty instead.",
         "property": "__defineSetter__",
       },
-      {
-        "message": "Use the exponentiation operator (**) instead.",
-        "object": "Math",
-        "property": "pow",
-      },
     ],
     "no-restricted-syntax": [
       2,
@@ -2099,7 +2037,7 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
       {
         "allow": [],
         "allowAfterSuper": false,
-        "allowAfterThis": false,
+        "allowAfterThis": true,
         "allowAfterThisConstructor": false,
         "allowFunctionParams": true,
         "allowInArrayDestructuring": true,
@@ -2358,9 +2296,6 @@ exports[`Resolved config matches snapshot > typescript.ts 1`] = `
         "requireStringLiterals": true,
       },
     ],
-    "vars-on-top": [
-      2,
-    ],
     "yoda": [
       2,
       "never",
@@ -2407,7 +2342,7 @@ exports[`Resolved config matches snapshot > typescript.ts 2`] = `
 "- Editor mode: false  - 3
 + Editor mode: true   + 0
 
-@@ -1234,13 +1234,10 @@
+@@ -1204,13 +1204,10 @@
         2,
         Object {
           "withDash": false,
@@ -3946,10 +3881,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     "@typescript-eslint/naming-convention": [
       2,
       {
-        "custom": {
-          "match": true,
-          "regex": "^I[A-Z]",
-        },
         "format": [
           "PascalCase",
         ],
@@ -4131,9 +4062,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
         "checkForEach": false,
       },
     ],
-    "block-scoped-var": [
-      2,
-    ],
     "camelcase": [
       2,
       {
@@ -4183,11 +4111,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     "for-direction": [
       2,
     ],
-    "func-names": [
-      1,
-      "always",
-      {},
-    ],
     "getter-return": [
       0,
       {
@@ -4200,9 +4123,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
       {
         "enforceForTSTypes": true,
       },
-    ],
-    "guard-for-in": [
-      2,
     ],
     "import-x/export": [
       2,
@@ -4530,18 +4450,22 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
       2,
       "never",
     ],
-    "max-classes-per-file": [
-      2,
-      1,
-    ],
     "new-cap": [
       2,
       {
         "capIsNew": false,
         "capIsNewExceptions": [
-          "Immutable.Map",
-          "Immutable.Set",
-          "Immutable.List",
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt",
         ],
         "newIsCap": true,
         "newIsCapExceptions": [],
@@ -4597,9 +4521,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
       },
     ],
     "no-constructor-return": [
-      2,
-    ],
-    "no-continue": [
       2,
     ],
     "no-control-regex": [
@@ -4725,9 +4646,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
         "skipTemplates": false,
       },
     ],
-    "no-iterator": [
-      2,
-    ],
     "no-label-var": [
       2,
     ],
@@ -4742,9 +4660,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
       2,
     ],
     "no-lonely-if": [
-      2,
-    ],
-    "no-loop-func": [
       2,
     ],
     "no-loss-of-precision": [
@@ -4811,8 +4726,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
           "request",
           "res",
           "response",
-          "$scope",
-          "staticContext",
         ],
         "props": true,
       },
@@ -4820,7 +4733,7 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
     "no-plusplus": [
       2,
       {
-        "allowForLoopAfterthoughts": false,
+        "allowForLoopAfterthoughts": true,
       },
     ],
     "no-promise-executor-return": [
@@ -4828,9 +4741,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
       {
         "allowVoid": false,
       },
-    ],
-    "no-proto": [
-      2,
     ],
     "no-prototype-builtins": [
       2,
@@ -4967,11 +4877,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
         "message": "Please use Object.defineProperty instead.",
         "property": "__defineSetter__",
       },
-      {
-        "message": "Use the exponentiation operator (**) instead.",
-        "object": "Math",
-        "property": "pow",
-      },
     ],
     "no-restricted-syntax": [
       2,
@@ -5060,7 +4965,7 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
       {
         "allow": [],
         "allowAfterSuper": false,
-        "allowAfterThis": false,
+        "allowAfterThis": true,
         "allowAfterThisConstructor": false,
         "allowFunctionParams": true,
         "allowInArrayDestructuring": true,
@@ -5376,9 +5281,6 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 1`] = `
         "requireStringLiterals": true,
       },
     ],
-    "vars-on-top": [
-      2,
-    ],
     "yoda": [
       2,
       "never",
@@ -5430,7 +5332,7 @@ exports[`Resolved config matches snapshot > typescript-react.tsx 2`] = `
 "- Editor mode: false  - 3
 + Editor mode: true   + 0
 
-@@ -2925,13 +2925,10 @@
+@@ -2895,13 +2895,10 @@
         2,
         Object {
           "withDash": false,

--- a/specs/eslint-configs/tests/presets.test.mts
+++ b/specs/eslint-configs/tests/presets.test.mts
@@ -180,8 +180,7 @@ describe('Presets does not contain style rules', () => {
   }
 });
 
-// FIXME: migrate these deprecated rules with alternatives or remove them?
-const ignoredDeprecatedRules = ['no-buffer-constructor'];
+const ignoredDeprecatedRules: string[] = [];
 const lintResults = await Promise.all(
   sampleFiles.map(async (file) => [
     basename(file),

--- a/specs/lint-eslint-config-rules/lint-eslint-config-rules.test.mts
+++ b/specs/lint-eslint-config-rules/lint-eslint-config-rules.test.mts
@@ -14,13 +14,7 @@ for (const dirent of specDirs) {
     const cwd = path.join(dirent.parentPath, dirent.name);
     const result = await lintESLintConfigRules(cwd);
     expect(result.usedDeprecatedRuleIds).toEqual(
-      new Set([
-        'indent-legacy',
-        'no-new-object',
-
-        // from extended configs
-        'no-buffer-constructor',
-      ]),
+      new Set(['indent-legacy', 'no-new-object']),
     );
     expect(result.usedUnknownRuleIds).toEqual(
       new Set(['unknown-rule-off', '@prefixed/unknown-rule-off']),


### PR DESCRIPTION
## Summary

Implements the rule changes discussed in #373. The `packages/eslint-config/src/config/base/*` rules were originally lifted from `eslint-config-airbnb-base@15.0.0` and reflect ES5 / pre-Prettier / pre-TypeScript defensive defaults. With Node 24 and modern browsers as the baseline, many of those rules are dead, redundant with TypeScript or other plugins, or fight idiomatic modern code.

### Removed (turned off)

| Rule | Reason |
|---|---|
| `no-continue`, `func-names` | Modern style — clean early-exit, arrow-first |
| `vars-on-top`, `block-scoped-var`, `no-loop-func` | Dead given `no-var` |
| `no-with`, `no-iterator`, `no-proto`, `no-buffer-constructor` | Banned in strict mode / removed from runtime / deprecated upstream |
| `max-classes-per-file` | Noisy for legitimate utility helpers |
| `guard-for-in` | Duplicate of existing `no-restricted-syntax` ban on `for…in` |

### Relaxed

| Rule | Change |
|---|---|
| `no-plusplus` | Allow in for-loop afterthoughts |
| `no-underscore-dangle` | Allow after `this` |
| `no-restricted-properties` | Drop the `Math.pow` entry (already covered by `prefer-exponentiation-operator`) |
| `new-cap` | Drop the `Immutable.*` exceptions (Immutable.js no longer used) |
| `no-param-reassign` | Drop the `$scope` (Angular 1.x) and `staticContext` (legacy `react-router`) entries |
| `@typescript-eslint/naming-convention` | Drop the legacy `^I[A-Z]` Hungarian-notation interface rule; keep PascalCase enforcement for interfaces (core `camelcase` only bans snake_case, so it can't enforce PascalCase on its own) |

### TypeScript-only overrides (kept on for JS files)

| Rule | Reason |
|---|---|
| `no-throw-literal` | Covered by typed-aware `@typescript-eslint/only-throw-error` |
| `no-array-constructor` | Covered by `@typescript-eslint/no-array-constructor` |
| `no-undef` | TypeScript catches it; typescript-eslint explicitly recommends disabling |

### Spec / test cleanups

- `specs/eslint-configs/tests/presets.test.mts` — emptied `ignoredDeprecatedRules` (the FIXME for `no-buffer-constructor` is now resolved)
- `specs/lint-eslint-config-rules/lint-eslint-config-rules.test.mts` — dropped `'no-buffer-constructor'` from the expected deprecated-rules set
- `presets.test.mts.snap` regenerated

### Version plan

`eslint: minor` — all changes are relaxations or removals; no consumer code that previously passed will start failing.

### Heads-up for downstream consumers

`linterOptions.reportUnusedDisableDirectives: true` is on, so existing `// eslint-disable-*-line …` comments in consumer codebases that targeted any of the now-removed/relaxed rules (e.g. `no-continue`, `no-plusplus`, `max-classes-per-file`) will start surfacing as "unused disable" errors after this lands. A one-pass cleanup of those directives is expected.

Refs #373

## Test plan

- [x] `pnpm run lint` ✓
- [x] `pnpm run test` ✓ (snapshots regenerated; both spec packages green)
- [x] `pnpm run check` ✓ (version plan validated)
- [ ] CI green
- [ ] Spot-check downstream impact in a major consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
