### PR TITLE
fix(renovate): keep actions workflow updates grouped

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,12 @@
       "matchPackageNames": ["eslint"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Keep RightCapitalHQ/actions reusable workflow updates grouped separately",
+      "groupName": "RightCapital actions",
+      "matchDepNames": ["RightCapitalHQ/actions/**"],
+      "minimumReleaseAge": null
     }
   ]
 }


### PR DESCRIPTION
## Summary
- keep RightCapitalHQ/actions reusable workflow updates in the dedicated RightCapital actions Renovate group
- prevent the local non-major dependency rule from swallowing those virtual deps

## Validation
- jq . renovate.json
- git diff --check