### PR TITLE
chore: add eslint config package metadata

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/RightCapitalHQ/frontend-style-guide.git",
     "directory": "packages/eslint-config"
   },
+  "bugs": {
+    "url": "https://github.com/RightCapitalHQ/frontend-style-guide/issues"
+  },
+  "homepage": "https://github.com/RightCapitalHQ/frontend-style-guide/tree/main/packages/eslint-config#readme",
   "license": "MIT",
   "type": "module",
   "exports": "./lib/index.js",


### PR DESCRIPTION
## Summary
Add npm support metadata to @rightcapital/eslint-config:
- bugs.url -> repository issue tracker
- homepage -> package README

Manifest-only change; no runtime code, exports, dependencies, versioning, or build output changed.

## Verification
- Parsed packages/eslint-config/package.json and confirmed name/license/homepage/bugs.url
- npm pack --dry-run --ignore-scripts --json from packages/eslint-config
- git diff --check