### PR TITLE
Add package support metadata to prettier config

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -2,10 +2,14 @@
   "name": "@rightcapital/prettier-config",
   "version": "8.0.5",
   "description": "Prettier Config for RightCapital",
+  "homepage": "https://github.com/RightCapitalHQ/frontend-style-guide#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/RightCapitalHQ/frontend-style-guide.git",
     "directory": "packages/prettier-config"
+  },
+  "bugs": {
+    "url": "https://github.com/RightCapitalHQ/frontend-style-guide/issues"
   },
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

Adds package support metadata to `@rightcapital/prettier-config` so npm users can find the package README and issue tracker directly from package metadata.

Changed only `packages/prettier-config/package.json`:

- adds `homepage` pointing to this repository README
- adds `bugs.url` pointing to this repository issue tracker

## Validation

```bash
node -e "const p=require('./packages/prettier-config/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,homepage:p.homepage,bugs:p.bugs,license:p.license},null,2)); if(p.name!=='@rightcapital/prettier-config'||p.homepage!=='https://github.com/RightCapitalHQ/frontend-style-guide#readme'||p.bugs?.url!=='https://github.com/RightCapitalHQ/frontend-style-guide/issues') process.exit(1)"
git diff --check
npm pack @rightcapital/prettier-config@8.0.5 --dry-run --json
```